### PR TITLE
Add Dockerfile and supporting commands for running docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM golang:1.16-alpine AS build-env
+
+# Set up dependencies
+ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
+
+# Set working directory for the build
+WORKDIR /go/src/github.com/persistenceOne/persistenceCore
+
+# Add source files
+COPY . .
+
+RUN go version
+
+# Install minimum necessary dependencies, build persistenceCore, remove packages
+RUN apk add --no-cache $PACKAGES && make install
+
+# Final image
+FROM alpine:edge
+
+# Install ca-certificates
+RUN apk add --update ca-certificates
+
+# Create appuser
+ENV USER=appuser
+ENV UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/app" \
+    --shell "/sbin/nologin" \
+    --uid "${UID}" \
+    "${USER}"
+USER 10001
+
+WORKDIR /app
+
+# Copy over binaries from the build-env
+COPY --from=build-env /go/bin/persistenceCore /usr/bin/persistenceCore
+
+# Run gaiad by default, omit entrypoint to ease using container with gaiacli
+CMD ["persistenceCore"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ WORKDIR /app
 # Copy over binaries from the build-env
 COPY --from=build-env /go/bin/persistenceCore /usr/bin/persistenceCore
 
-# Run gaiad by default, omit entrypoint to ease using container with gaiacli
+# Run persistenceCore by default, omit entrypoint to ease using container with cli
 CMD ["persistenceCore"]

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,18 @@ proto-gen:
 
 
 # Commands for running docker
+#
+# Run persistenceCore on docker
+# Example Usage:
+# 	make docker-build   ## Builds persistenceCore binary in 2 stages, 1st builder 2nd Runner
+# 						   Final image only has the compiled persistenceCore binary
+# 	make docker-interactive   ## Will start an shell session into the docker container
+# 								 Access to persistenceCore binary here
+# 		NOTE: To be used for testing only, since the container will be removed after stopping
+# 	make docker-run DOCKER_CMD=sleep 10000000 DOCKER_OPTS=-d   ## Will run the container in the background
+# 		NOTE: Recommeded to use docker commands directly for long running processes
+# 	make docker-clean  # Will clean up the running container, as well as delete the image
+# 						 after one is done testing
 docker-build:
 	${DOCKER} build -t ${DOCKER_IMAGE_NAME}:${DOCKER_TAG_NAME} .
 


### PR DESCRIPTION
- `Dockerfile` to build `persistenceCore` from source and results into a final light weight image with binary.
- Added supported make commands for building and test running the container, makefile has instructions in comments.

# Testing
Inorder to run quickly, run
```
make docker-build
make docker-interactive

# after testing
make docker-clean
```

# Note
For long term processes, it is recommend to use docker commands directly for now.