### PR TITLE
Add subspce function and init params keeper

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -100,6 +100,7 @@ import (
 	ibcKeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmClient "github.com/CosmWasm/wasmd/x/wasm/client"
+	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	wasmKeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	"github.com/gogo/protobuf/grpc"
 	"github.com/gorilla/mux"
@@ -121,7 +122,7 @@ var DefaultNodeHome string
 var (
 	// ProposalsEnabled is "true" and EnabledSpecificProposals is "", then enable all x/wasm proposals.
 	// ProposalsEnabled is not "true" and EnabledSpecificProposals is "", then disable all x/wasm proposals.
-	ProposalsEnabled = "false"
+	ProposalsEnabled = "true"
 	// EnableSpecificProposals if set to non-empty string it must be comma-separated list of values that are all a subset
 	// of "EnableAllProposals" (takes precedence over ProposalsEnabled)
 	// https://github.com/CosmWasm/wasmd/blob/02a54d33ff2c064f3539ae12d75d027d9c665f05/x/wasm/internal/types/proposal.go#L28-L34
@@ -295,7 +296,7 @@ func NewApplication(
 		keys: keys,
 	}
 
-	app.ParamsKeeper = paramsKeeper.NewKeeper(
+	app.ParamsKeeper = initParamsKeeper(
 		applicationCodec,
 		legacyAmino,
 		keys[paramsTypes.StoreKey],
@@ -313,7 +314,7 @@ func NewApplication(
 	app.AccountKeeper = authKeeper.NewAccountKeeper(
 		applicationCodec,
 		keys[authTypes.StoreKey],
-		app.ParamsKeeper.Subspace(authTypes.ModuleName),
+		app.GetSubspace(authTypes.ModuleName),
 		authTypes.ProtoBaseAccount,
 		moduleAccountPermissions,
 	)
@@ -331,7 +332,7 @@ func NewApplication(
 		applicationCodec,
 		keys[bankTypes.StoreKey],
 		app.AccountKeeper,
-		app.ParamsKeeper.Subspace(bankTypes.ModuleName),
+		app.GetSubspace(bankTypes.ModuleName),
 		blacklistedAddresses,
 	)
 
@@ -352,13 +353,13 @@ func NewApplication(
 		keys[stakingTypes.StoreKey],
 		app.AccountKeeper,
 		app.BankKeeper,
-		app.ParamsKeeper.Subspace(stakingTypes.ModuleName),
+		app.GetSubspace(stakingTypes.ModuleName),
 	)
 
 	app.MintKeeper = mintKeeper.NewKeeper(
 		applicationCodec,
 		keys[mintTypes.StoreKey],
-		app.ParamsKeeper.Subspace(mintTypes.ModuleName),
+		app.GetSubspace(mintTypes.ModuleName),
 		&stakingKeeper,
 		app.AccountKeeper,
 		app.BankKeeper,
@@ -368,7 +369,7 @@ func NewApplication(
 	app.DistributionKeeper = distributionKeeper.NewKeeper(
 		applicationCodec,
 		keys[distributionTypes.StoreKey],
-		app.ParamsKeeper.Subspace(distributionTypes.ModuleName),
+		app.GetSubspace(distributionTypes.ModuleName),
 		app.AccountKeeper,
 		app.BankKeeper,
 		&stakingKeeper,
@@ -379,10 +380,10 @@ func NewApplication(
 		applicationCodec,
 		keys[slashingTypes.StoreKey],
 		&stakingKeeper,
-		app.ParamsKeeper.Subspace(slashingTypes.ModuleName),
+		app.GetSubspace(slashingTypes.ModuleName),
 	)
 	app.CrisisKeeper = crisisKeeper.NewKeeper(
-		app.ParamsKeeper.Subspace(crisisTypes.ModuleName),
+		app.GetSubspace(crisisTypes.ModuleName),
 		invCheckPeriod,
 		app.BankKeeper,
 		authTypes.FeeCollectorName,
@@ -397,7 +398,7 @@ func NewApplication(
 
 	app.HalvingKeeper = halving.NewKeeper(
 		keys[halving.StoreKey],
-		app.ParamsKeeper.Subspace(halving.DefaultParamspace),
+		app.GetSubspace(halving.DefaultParamspace),
 		app.MintKeeper,
 	)
 
@@ -408,7 +409,7 @@ func NewApplication(
 	app.IBCKeeper = ibcKeeper.NewKeeper(
 		applicationCodec,
 		keys[ibcHost.StoreKey],
-		app.ParamsKeeper.Subspace(ibcHost.ModuleName),
+		app.GetSubspace(ibcHost.ModuleName),
 		app.StakingKeeper,
 		app.UpgradeKeeper,
 		scopedIBCKeeper,
@@ -417,7 +418,7 @@ func NewApplication(
 	app.TransferKeeper = ibcTransferKeeper.NewKeeper(
 		applicationCodec,
 		keys[ibcTransferTypes.StoreKey],
-		app.ParamsKeeper.Subspace(ibcTransferTypes.ModuleName),
+		app.GetSubspace(ibcTransferTypes.ModuleName),
 		app.IBCKeeper.ChannelKeeper,
 		app.IBCKeeper.ChannelKeeper,
 		&app.IBCKeeper.PortKeeper,
@@ -431,7 +432,7 @@ func NewApplication(
 	app.ICAHostKeeper = icaHostKeeper.NewKeeper(
 		applicationCodec,
 		keys[icaHostTypes.StoreKey],
-		app.ParamsKeeper.Subspace(icaHostTypes.SubModuleName),
+		app.GetSubspace(icaHostTypes.SubModuleName),
 		app.IBCKeeper.ChannelKeeper,
 		&app.IBCKeeper.PortKeeper,
 		app.AccountKeeper,
@@ -462,7 +463,7 @@ func NewApplication(
 	app.WasmKeeper = wasm.NewKeeper(
 		applicationCodec,
 		keys[wasm.StoreKey],
-		app.ParamsKeeper.Subspace(wasm.ModuleName),
+		app.GetSubspace(wasm.ModuleName),
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.StakingKeeper,
@@ -505,7 +506,7 @@ func NewApplication(
 	app.GovKeeper = govKeeper.NewKeeper(
 		applicationCodec,
 		keys[govTypes.StoreKey],
-		app.ParamsKeeper.Subspace(govTypes.ModuleName).WithKeyTable(govTypes.ParamKeyTable()),
+		app.GetSubspace(govTypes.ModuleName),
 		app.AccountKeeper,
 		app.BankKeeper,
 		&stakingKeeper,
@@ -690,7 +691,9 @@ func NewApplication(
 	app.UpgradeKeeper.SetUpgradeHandler(
 		UpgradeName,
 		func(ctx sdk.Context, _ upgradeTypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			ctx.Logger().Info("Inside the upgrade handler")
 			app.IBCKeeper.ConnectionKeeper.SetParams(ctx, ibcConnectionTypes.DefaultParams())
+
 			fromVM[icaTypes.ModuleName] = icaModule.ConsensusVersion()
 			// create ICS27 Controller submodule params
 			controllerParams := icaControllerTypes.Params{}
@@ -729,8 +732,19 @@ func NewApplication(
 			ctx.Logger().Info("start to run module migrations...")
 
 			// RunMigrations twice is just a way to make auth module's migrates after staking
-			return app.moduleManager.RunMigrations(ctx, app.configurator, fromVM)
+			newVM, err := app.moduleManager.RunMigrations(ctx, app.configurator, fromVM)
+			if err != nil {
+				return nil, err
+			}
 
+			// Since we provide custom DefaultGenesis (privileges StoreCode) in
+			// app/genesis.go rather than the wasm module, we need to set the params
+			// here when migrating (is it is not customized).
+			params := app.WasmKeeper.GetParams(ctx)
+			params.CodeUploadAccess = wasmTypes.AllowNobody
+			app.WasmKeeper.SetParams(ctx, params)
+
+			return newVM, nil
 		},
 	)
 
@@ -741,7 +755,7 @@ func NewApplication(
 
 	if upgradeInfo.Name == UpgradeName && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storeTypes.StoreUpgrades{
-			Added: []string{authz.ModuleName, feegrant.ModuleName},
+			Added: []string{wasm.ModuleName},
 		}
 
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades
@@ -958,6 +972,11 @@ func (app Application) ModuleAccountAddrs() map[string]bool {
 	return modAccAddrs
 }
 
+func (app *Application) GetSubspace(moduleName string) paramsTypes.Subspace {
+	subspace, _ := app.ParamsKeeper.GetSubspace(moduleName)
+	return subspace
+}
+
 func (app Application) SimulationManager() *module.SimulationManager {
 	return app.simulationManager
 }
@@ -1022,4 +1041,25 @@ func (app Application) RegisterTendermintService(clientCtx client.Context) {
 
 func (app Application) LoadHeight(height int64) error {
 	return app.BaseApp.LoadVersion(height)
+}
+
+// initParamsKeeper init params keeper and its subspaces.
+func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey sdk.StoreKey) paramsKeeper.Keeper {
+	paramsKeeper := paramsKeeper.NewKeeper(appCodec, legacyAmino, key, tkey)
+
+	paramsKeeper.Subspace(authTypes.ModuleName)
+	paramsKeeper.Subspace(bankTypes.ModuleName)
+	paramsKeeper.Subspace(stakingTypes.ModuleName)
+	paramsKeeper.Subspace(mintTypes.ModuleName)
+	paramsKeeper.Subspace(distributionTypes.ModuleName)
+	paramsKeeper.Subspace(slashingTypes.ModuleName)
+	paramsKeeper.Subspace(crisisTypes.ModuleName)
+	paramsKeeper.Subspace(halving.DefaultParamspace)
+	paramsKeeper.Subspace(govTypes.ModuleName).WithKeyTable(govTypes.ParamKeyTable())
+	paramsKeeper.Subspace(ibcTransferTypes.ModuleName)
+	paramsKeeper.Subspace(ibcHost.ModuleName)
+	paramsKeeper.Subspace(icaHostTypes.SubModuleName)
+	paramsKeeper.Subspace(wasm.ModuleName)
+
+	return paramsKeeper
 }

--- a/app/app.go
+++ b/app/app.go
@@ -753,7 +753,7 @@ func NewApplication(
 
 	if upgradeInfo.Name == UpgradeName && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storeTypes.StoreUpgrades{
-			Added: []string{wasm.ModuleName},
+			Added: []string{icaHostTypes.StoreKey, wasm.ModuleName},
 		}
 
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades

--- a/app/app.go
+++ b/app/app.go
@@ -692,7 +692,6 @@ func NewApplication(
 		UpgradeName,
 		func(ctx sdk.Context, _ upgradeTypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			ctx.Logger().Info("Inside the upgrade handler")
-			app.IBCKeeper.ConnectionKeeper.SetParams(ctx, ibcConnectionTypes.DefaultParams())
 
 			fromVM[icaTypes.ModuleName] = icaModule.ConsensusVersion()
 			// create ICS27 Controller submodule params

--- a/app/app.go
+++ b/app/app.go
@@ -691,7 +691,7 @@ func NewApplication(
 	app.UpgradeKeeper.SetUpgradeHandler(
 		UpgradeName,
 		func(ctx sdk.Context, _ upgradeTypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			ctx.Logger().Info("Inside the upgrade handler")
+			ctx.Logger().Info("starting the upgrade now")
 
 			fromVM[icaTypes.ModuleName] = icaModule.ConsensusVersion()
 			// create ICS27 Controller submodule params

--- a/app/app.go
+++ b/app/app.go
@@ -27,6 +27,7 @@ import (
 	storeTypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authRest "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
@@ -94,7 +95,6 @@ import (
 	ibcCoreClient "github.com/cosmos/ibc-go/v3/modules/core/02-client"
 	ibcClient "github.com/cosmos/ibc-go/v3/modules/core/02-client/client"
 	ibcClientTypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
-	ibcConnectionTypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	ibcTypes "github.com/cosmos/ibc-go/v3/modules/core/05-port/types"
 	ibcHost "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 	ibcKeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
@@ -111,7 +111,6 @@ import (
 	tendermintOS "github.com/tendermint/tendermint/libs/os"
 	tendermintProto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tendermintDB "github.com/tendermint/tm-db"
-	"honnef.co/go/tools/version"
 
 	appParams "github.com/persistenceOne/persistenceCore/app/params"
 	"github.com/persistenceOne/persistenceCore/x/halving"

--- a/app/constants.go
+++ b/app/constants.go
@@ -12,7 +12,7 @@ import (
 const (
 	Name             = "PersistenceCore"
 	Bech32MainPrefix = "persistence"
-	UpgradeName      = "v3"
+	UpgradeName      = "v3-wasm"
 	CoinType         = 750
 	Purpose 		 = 44
 

--- a/app/constants.go
+++ b/app/constants.go
@@ -12,7 +12,7 @@ import (
 const (
 	Name             = "PersistenceCore"
 	Bech32MainPrefix = "persistence"
-	UpgradeName      = "v3-wasm"
+	UpgradeName      = "v3"
 	CoinType         = 750
 	Purpose 		 = 44
 

--- a/contrib/local/Makefile
+++ b/contrib/local/Makefile
@@ -2,6 +2,8 @@ CHAIN_ID := testing
 CHAIN_DIR := /tmp/trash
 CHAIN_BIN := ./../../build/persistenceCore
 
+all: clean setup start
+
 .bash:
 	CHAIN_ID=$(CHAIN_ID) \
 	HOME=$(CHAIN_DIR) \
@@ -15,21 +17,20 @@ clean:
 	rm -rf $(CHAIN_DIR)
 
 start:
-	HOME=$(CHAIN_DIR) $(CHAIN_BIN) start --minimum-gas-prices="0.0005stake"
+	HOME=$(CHAIN_DIR) $(CHAIN_BIN) start --minimum-gas-prices="0.0005stake" $(ARGS)
 
 ###############################################################################
 ###                              Test commands                              ###
 ###############################################################################
 
-software-upgrade:
-	$(CHAIN_BIN) tx gov submit-proposal software-upgrade v3 --yes \
-		--title "Test local upgrade" \
-		--description "Test local upgrade" \
-		--upgrade-height $(HEIGHT) \
-		--from $(jq -r .genesis[0].address $(VALIDATOR_CONFIG)) \
-		--chain-id $(CHAIN_ID) \
-		--deposit 600000000stake \
-		--upgrade-info "The binary for this upgrade should be built from v0.2.x tagged or from master branch"
-
 run-contract:
 	$(MAKE) .bash SCRIPT_FILE=contract.sh
+
+run-gov-contract:
+	$(MAKE) .bash SCRIPT_FILE=gov_contract.sh
+
+run-test:
+	$(MAKE) .bash SCRIPT_FILE=test.sh
+
+run-upgrade:
+	$(MAKE) .bash SCRIPT_FILE=upgrade.sh

--- a/contrib/local/gov_contract.sh
+++ b/contrib/local/gov_contract.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -eu
+
+DIR="$HOME/test-contracts"
+mkdir -p $DIR
+
+echo "-----------------------"
+echo "## Add new CosmWasm contract via gov proposal"
+wget "https://github.com/CosmWasm/wasmd/raw/14688c09855ee928a12bcb7cd102a53b78e3cbfb/x/wasm/keeper/testdata/hackatom.wasm" -q -O $DIR/hackatom.wasm
+VAL1_KEY=$($CHAIN_BIN keys show -a val1)
+RESP=$($CHAIN_BIN tx gov submit-proposal wasm-store "$DIR/hackatom.wasm" \
+  --title "hackatom" \
+  --description "hackatom test contact" \
+  --deposit 10000stake \
+  --run-as $VAL1_KEY \
+  --instantiate-everybody "true" \
+  --keyring-backend test \
+  --from val1 --gas auto --fees 10000stake -y \
+  --chain-id $CHAIN_ID \
+  -b block -o json --gas-adjustment 1.5)
+echo "$RESP"
+PROPOSAL_ID=$(echo "$RESP" | jq -r '.logs[0].events[] | select(.type == "submit_proposal") | .attributes[] | select(.key == "proposal_id") | .value')
+
+echo "### Query proposal prevote"
+$CHAIN_BIN q gov proposal $PROPOSAL_ID -o json | jq
+
+echo "### Vote proposal"
+$CHAIN_BIN tx gov vote $PROPOSAL_ID yes --from val1 --yes --chain-id $CHAIN_ID \
+    --fees 500stake --gas auto --gas-adjustment 1.5 -b block -o json | jq
+$CHAIN_BIN tx gov vote $PROPOSAL_ID yes --from test1 --yes --chain-id $CHAIN_ID \
+    --fees 500stake --gas auto --gas-adjustment 1.5 -b block -o json | jq
+$CHAIN_BIN tx gov vote $PROPOSAL_ID yes --from test2 --yes --chain-id $CHAIN_ID \
+    --fees 500stake --gas auto --gas-adjustment 1.5 -b block -o json | jq
+
+echo "### Query proposal postvote"
+$CHAIN_BIN q gov proposal $PROPOSAL_ID -o json | jq
+
+echo "### Waiting for voting period..."
+sleep 40
+$CHAIN_BIN q wasm list-code -o json | jq
+
+CODE_ID=$($CHAIN_BIN q wasm list-code -o json | jq -r ".code_infos[-1].code_id")
+
+echo "-----------------------"
+echo "## Create new contract instance"
+INIT="{\"verifier\":\"$($CHAIN_BIN keys show val1 -a --keyring-backend test)\", \"beneficiary\":\"$($CHAIN_BIN keys show test1 -a)\"}"
+$CHAIN_BIN tx wasm instantiate "$CODE_ID" "$INIT" --admin="$($CHAIN_BIN keys show val1 -a --keyring-backend test)" \
+  --from val1 --amount "10000stake" --label "local0.1.0" --gas-adjustment 1.5 --fees "10000stake" \
+  --gas "auto" -y --chain-id $CHAIN_ID -b block -o json | jq
+
+CONTRACT=$($CHAIN_BIN query wasm list-contract-by-code "$CODE_ID" -o json | jq -r '.contracts[-1]')
+echo "* Contract address: $CONTRACT"
+
+echo "### Query all"
+RESP=$($CHAIN_BIN query wasm contract-state all "$CONTRACT" -o json)
+echo "$RESP" | jq
+echo "### Query smart"
+$CHAIN_BIN query wasm contract-state smart "$CONTRACT" '{"verifier":{}}' -o json | jq
+echo "### Query raw"
+KEY=$(echo "$RESP" | jq -r ".models[0].key")
+$CHAIN_BIN query wasm contract-state raw "$CONTRACT" "$KEY" -o json | jq
+
+echo "-----------------------"
+echo "## Execute contract $CONTRACT"
+MSG='{"release":{}}'
+$CHAIN_BIN tx wasm execute "$CONTRACT" "$MSG" \
+  --from val1 --gas-adjustment 1.5 --fees "10000stake" \
+  --gas "auto" -y --chain-id $CHAIN_ID -b block -o json | jq
+
+echo "-----------------------"
+echo "## Set new admin"
+echo "### Query old admin: $($CHAIN_BIN q wasm contract "$CONTRACT" -o json | jq -r '.contract_info.admin')"
+echo "### Update contract"
+$CHAIN_BIN tx wasm set-contract-admin "$CONTRACT" "$($CHAIN_BIN keys show test1 -a)" \
+  --from val1 --gas-adjustment 1.5 --gas "auto" --fees "10000stake" -y --chain-id $CHAIN_ID -b block -o json | jq
+echo "### Query new admin: $($CHAIN_BIN q wasm contract "$CONTRACT" -o json | jq -r '.contract_info.admin')"
+

--- a/contrib/local/setup.sh
+++ b/contrib/local/setup.sh
@@ -13,9 +13,9 @@ jq -r ".genesis[0].mnemonic" $VALIDATOR_CONFIG | $CHAIN_BIN init $CHAIN_ID --cha
 jq -r ".genesis[0].mnemonic" $VALIDATOR_CONFIG | $CHAIN_BIN keys add $(jq -r ".genesis[0].name" $VALIDATOR_CONFIG) --recover --keyring-backend="test"
 
 # Add keys to keyringg
-for ((i=0; i<$(jq -r '.validators | length' $KEYS_CONFIG); i++))
+for ((i=0; i<$(jq -r '.validators | length' $VALIDATOR_CONFIG); i++))
 do
-  jq -r ".validators[$i].mnemonic" $KEYS_CONFIG | $CHAIN_BIN keys add $(jq -r ".validators[$i].name" $KEYS_CONFIG) --recover --keyring-backend="test"
+  jq -r ".validators[$i].mnemonic" $VALIDATOR_CONFIG | $CHAIN_BIN keys add $(jq -r ".validators[$i].name" $VALIDATOR_CONFIG) --recover --keyring-backend="test"
 done
 
 for ((i=0; i<$(jq -r '.keys | length' $KEYS_CONFIG); i++))

--- a/contrib/local/upgrade.sh
+++ b/contrib/local/upgrade.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+OFFSET_HEIGHT=40
+UPGRADE_NAME=v3-wasm
+
+set -o errexit -o nounset -o pipefail -eu
+
+$CHAIN_BIN status 2>&1 | jq
+
+CURRENT_HEIGHT=$($CHAIN_BIN status 2>&1 | jq -r ".SyncInfo.latest_block_height")
+UPGRADE_HEIGHT=`expr $CURRENT_HEIGHT + $OFFSET_HEIGHT`
+echo "Starting software upgrade"
+
+echo "### Submit proposal from val1"
+RESP=$($CHAIN_BIN tx gov submit-proposal software-upgrade $UPGRADE_NAME --yes --title "$UPGRADE_NAME" --description "$UPGRADE_NAME" \
+    --upgrade-height $UPGRADE_HEIGHT --from val1 --chain-id $CHAIN_ID --deposit 100stake \
+    --fees 2000stake --gas auto --gas-adjustment 1.5 -b block -o json)
+PROPOSAL_ID=$(echo "$RESP" | jq -r '.logs[0].events[] | select(.type == "submit_proposal") | .attributes[] | select(.key == "proposal_id") | .value')
+
+echo "### Query proposal prevote"
+$CHAIN_BIN q gov proposal $PROPOSAL_ID -o json | jq
+
+echo "### Vote proposal"
+$CHAIN_BIN tx gov vote $PROPOSAL_ID yes --from val1 --yes --chain-id $CHAIN_ID \
+    --fees 200stake --gas auto --gas-adjustment 1.5 -b block -o json | jq
+$CHAIN_BIN tx gov vote $PROPOSAL_ID yes --from test1 --yes --chain-id $CHAIN_ID \
+    --fees 200stake --gas auto --gas-adjustment 1.5 -b block -o json | jq
+$CHAIN_BIN tx gov vote $PROPOSAL_ID yes --from test2 --yes --chain-id $CHAIN_ID \
+    --fees 200stake --gas auto --gas-adjustment 1.5 -b block -o json | jq
+
+echo "### Query proposal postvote"
+$CHAIN_BIN q gov proposal $PROPOSAL_ID -o json | jq

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/persistenceOne/persistenceCore
 go 1.17
 
 require (
-	github.com/CosmWasm/wasmd v0.27.1-0.20220607123528-14688c09855e
+	github.com/CosmWasm/wasmd v0.27.0
 	github.com/cosmos/cosmos-sdk v0.45.4
 	github.com/cosmos/ibc-go/v3 v3.0.0
 	github.com/gogo/protobuf v1.3.3
@@ -14,15 +14,16 @@ require (
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.4.0
-	github.com/stretchr/testify v1.7.2
+	github.com/stretchr/testify v1.7.1
 	github.com/tendermint/tendermint v0.34.19
 	github.com/tendermint/tm-db v0.6.7
 	google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac
 	google.golang.org/grpc v1.45.0
 	gopkg.in/yaml.v2 v2.4.0
-	honnef.co/go/tools v0.0.1-2020.1.4
 
 )
+
+require github.com/rogpeppe/go-internal v1.8.1 // indirect
 
 require (
 	filippo.io/edwards25519 v1.0.0-beta.2 // indirect
@@ -99,6 +100,7 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
 	github.com/regen-network/cosmos-proto v0.3.1 // indirect
+	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/zerolog v1.26.0 // indirect
 	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // indirect

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,6 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
 	github.com/regen-network/cosmos-proto v0.3.1 // indirect
-	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/zerolog v1.26.0 // indirect
 	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,6 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQ
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/CosmWasm/wasmd v0.27.0 h1:GYctl+sqCa8zpDTTUhX0/nf/4ej9J7x/88UmKH9V6Nc=
 github.com/CosmWasm/wasmd v0.27.0/go.mod h1:iiHoIuoCjR7kV4cS7PPt4NmyOXv+V9kohRQBsFIreMU=
-github.com/CosmWasm/wasmd v0.27.1-0.20220607123528-14688c09855e h1:Cgx/jN0XkoymLTu50HMKjbKg8SCNoOQ8YUZdIsVyJGQ=
-github.com/CosmWasm/wasmd v0.27.1-0.20220607123528-14688c09855e/go.mod h1:RZtMSAXRUD0GAMeYSWZEsfDOu5NMDXv76gK5MpqQXQU=
 github.com/CosmWasm/wasmvm v1.0.0 h1:NRmnHe3xXsKn2uEcB1F5Ha323JVAhON+BI6L177dlKc=
 github.com/CosmWasm/wasmvm v1.0.0/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx0FCXc+A=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
@@ -326,6 +324,8 @@ github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVB
 github.com/franela/goblin v0.0.0-20210519012713-85d372ac71e2/go.mod h1:VzmDKDJVZI3aJmnRI9VjAn9nJ8qPPsN1fqzr9dqInIo=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
+github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
@@ -625,6 +625,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -801,6 +803,7 @@ github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -821,7 +824,6 @@ github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3O
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.8.0/go.mod h1:O9VU6huf47PktckDQfMTX0Y8tY0/7TSWwj+ITvv0TnM=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.12.2 h1:51L9cDoUHVrXx4zWYlcLQIZ+d+VXHgqnYKkIuq4g/34=
 github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
@@ -872,6 +874,9 @@ github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRr
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
@@ -919,7 +924,6 @@ github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
@@ -967,8 +971,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
-github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -1624,7 +1626,6 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -1635,7 +1636,6 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 nhooyr.io/websocket v1.8.6 h1:s+C3xAMLwGmlI31Nyn/eAehUlZPwfYZu2JXM621Q5/k=
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=


### PR DESCRIPTION
## 1. Overview

Add permissioned wasm module and set update store loader.

## 2. Implementation details
* Create `initParamsKeeper` function
* Set wasm params so that it can not be stored directly, but via proposals

## 3. How to test/use
* Build binary with `make build`
* `cd contrib/local`
* Run `make`, this will start a new chain and run it
* In a seperate terminal run `make run-gov-upgrade`, this will test submitting a contract via a proposal, then instantiate the contract and run some sample execution command on them.

### Testing Upgrades
* After running the chain with a previous version binary
* Run `make run-upgrade`

## 4. Checklist

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)
* Currently this upgrade is not actually working since testing a software upgrade from `v0.2.3` does not seem to work
* The implementation for wasm does not seem to be the problem, since software upgrade actually works from commit `9bf5dde`

## 6. Future Work (optional)
* Debug refactor done to the application