### PR TITLE
Add docker based wasm testing scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Folders we don't want to copy to Docker daemon in `docker build . -t cosmwasm/wasmd:latest`
+build/
+bin/

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ vendor/
 target/
 build/
 release/
+bin/
 
 *.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ RUN apk add --no-cache $PACKAGES
 
 WORKDIR /opt
 
-# rest server, p2p, rpc
-EXPOSE 1317 26656 26657
+# rest server, p2p, rpc, grpc
+EXPOSE 1317 26656 26657 9090
 
 # Run persistenceCore by default, omit entrypoint to ease using container with cli
 CMD ["/usr/bin/persistenceCore", "version", "--long"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,22 @@
-FROM golang:1.16-alpine
+FROM golang:1.18-alpine3.16 AS go-builder
 
 # Set up dependencies
-ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
+ENV PACKAGES curl make git libusb-dev libc-dev bash gcc linux-headers eudev-dev python3
+
+# Install ca-certificates
+RUN set -eux; apk add --no-cache ca-certificates build-base;
+
+# Install minimum necessary dependencies
+RUN apk add --no-cache $PACKAGES
+
+# See https://github.com/CosmWasm/wasmvm/releases
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
+
+# Copy the library you want to the final location that will be found by the linker flag `-lwasmvm_muslc`
+RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 
 # Set working directory for the build
 WORKDIR /usr/local/app
@@ -9,11 +24,29 @@ WORKDIR /usr/local/app
 # Add source files
 COPY . .
 
-# Install minimum necessary dependencies, build persistenceCore, remove packages
-RUN apk add --no-cache $PACKAGES && make install
+# Force it to use static lib (from above) not standard libgo_cosmwasm.so file
+RUN LEDGER_ENABLED=false BUILD_TAGS="muslc linkstatic" make build
+RUN echo "Ensuring binary is statically linked ..." \
+  && (file /usr/local/app/build/persistenceCore | grep "statically linked")
 
-# Install ca-certificates
-RUN apk add --update ca-certificates
+FROM alpine:3.16
+
+COPY --from=go-builder /usr/local/app/build/persistenceCore /usr/bin/persistenceCore
+
+COPY contrib/local/ /opt/
+RUN chmod +x /opt/*.sh
+
+# Set up dependencies
+ENV PACKAGES curl make bash jq
+ENV CHAIN_BIN /usr/bin/persistenceCore
+
+# Install minimum necessary dependencies
+RUN apk add --no-cache $PACKAGES
+
+WORKDIR /opt
+
+# rest server, p2p, rpc
+EXPOSE 1317 26656 26657
 
 # Run persistenceCore by default, omit entrypoint to ease using container with cli
-CMD ["persistenceCore"]
+CMD ["/usr/bin/persistenceCore", "version", "--long"]

--- a/contrib/local/Makefile
+++ b/contrib/local/Makefile
@@ -2,6 +2,7 @@ CHAIN_ID := testing
 
 CHAIN_DIR ?= /tmp/trash
 CHAIN_BIN ?= ./../../build/persistenceCore
+WASM_PERMISSIONLESS ?= false
 
 all: clean setup start
 
@@ -9,6 +10,7 @@ all: clean setup start
 	CHAIN_ID=$(CHAIN_ID) \
 	HOME=$(CHAIN_DIR) \
 	CHAIN_BIN=$(CHAIN_BIN) \
+	WASM_PERMISSIONLESS=$(WASM_PERMISSIONLESS) \
 	bash $(SCRIPT_FILE)
 
 setup:
@@ -49,7 +51,8 @@ DOCKER_CONTAINER := persistence-core-container
 DOCKER_ENV ?= \
 	-e HOME=/opt \
 	-e CHAIN_DIR=/opt \
-	-e CHAIN_BIN=/usr/bin/persistenceCore
+	-e CHAIN_BIN=/usr/bin/persistenceCore \
+	-e WASM_PERMISSIONLESS=$(WASM_PERMISSIONLESS)
 
 docker-setup: docker-clean
 	$(DOCKER) run --rm -d \

--- a/contrib/local/Makefile
+++ b/contrib/local/Makefile
@@ -1,6 +1,7 @@
 CHAIN_ID := testing
-CHAIN_DIR := /tmp/trash
-CHAIN_BIN := ./../../build/persistenceCore
+
+CHAIN_DIR ?= /tmp/trash
+CHAIN_BIN ?= ./../../build/persistenceCore
 
 all: clean setup start
 
@@ -14,7 +15,7 @@ setup:
 	$(MAKE) .bash SCRIPT_FILE=setup.sh
 
 clean:
-	rm -rf $(CHAIN_DIR)
+	rm -rf $(CHAIN_DIR)/.persistenceCore
 
 start:
 	HOME=$(CHAIN_DIR) $(CHAIN_BIN) start --minimum-gas-prices="0.0005stake" $(ARGS)
@@ -34,3 +35,30 @@ run-test:
 
 run-upgrade:
 	$(MAKE) .bash SCRIPT_FILE=upgrade.sh
+
+###############################################################################
+###                              Docker commands                            ###
+###############################################################################
+
+# Docker variables
+DOCKER := $(shell which docker)
+
+DOCKER_IMAGE_NAME = persistenceone/persistencecore
+DOCKER_TAG_NAME = latest
+DOCKER_CONTAINER := persistence-core-container
+DOCKER_ENV ?= \
+	-e HOME=/opt \
+	-e CHAIN_DIR=/opt \
+	-e CHAIN_BIN=/usr/bin/persistenceCore
+
+docker-setup: docker-clean
+	$(DOCKER) run --rm -d \
+		--name=$(DOCKER_CONTAINER) \
+		$(DOCKER_ENV) \
+		$(DOCKER_IMAGE_NAME):$(DOCKER_TAG_NAME) make
+
+docker-exec:
+	$(DOCKER) exec -it $(DOCKER_CONTAINER) /bin/bash
+
+docker-clean:
+	-$(DOCKER) stop $(DOCKER_CONTAINER)

--- a/contrib/local/README.md
+++ b/contrib/local/README.md
@@ -1,0 +1,37 @@
+# Local net
+
+Scripts for running local net locally
+
+## In system
+* First build the binaries with `make build` in root directory.
+* Change directory into `cd contrib/local`
+* `make`: Runs cleanup, `setup.sh` script, start node.
+  * Initiate the gensis file
+  * Override the config params
+* Above command will be blocking, hence advised to run in a separate terminal
+* Run test commands
+  * `make run-gov-contract`: Create proposal via proposal, vote on the proposal, and initiate the contract, run test commands
+* `make clean` cleanup
+
+## In Docker
+* `make docker-setup`: Pull the core image, and run `make` command, run in background
+* `make docker-exec`: Open and bash shell into the background container, can run further test commands there
+  * `make run-gov-contract` inside the container
+* `make docker-clean`: Cleanup the containers after testing
+
+## Permissionless wasm
+By default the chain runs with wasm as a permissioned module where all the contracts
+are uploaded via a gov proposal. Inorder to start the chain as permissionless use
+following
+```bash
+# system
+WASM_PERMISSIONLESS=true make clean setup
+## or
+WASM_PERMISSIONLESS=true make
+
+# for docker
+WASM_PERMISSIONLESS=true make docker-setup
+```
+
+With this we start the container such that the wasm module runns in permissionless fashion. For testing,
+run `make run-contract` for permissionless contract testing.

--- a/contrib/local/setup.sh
+++ b/contrib/local/setup.sh
@@ -62,6 +62,13 @@ jq -r '.app_state.gov.voting_params.voting_period |= "30s"' $HOME/.persistenceCo
 jq -r '.app_state.gov.tally_params.quorum |= "0.000000000000000000"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
 jq -r '.app_state.gov.tally_params.threshold |= "0.000000000000000000"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
 jq -r '.app_state.gov.tally_params.veto_threshold |= "0.000000000000000000"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
-jq -r '.app_state.wasm.params.code_upload_access.permission |= "Nobody"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
+
+# Set wasm as permissioned or permissionless based on environment variable
+wasm_permission="Nobody"
+if [ $WASM_PERMISSIONLESS == "true" ]
+then
+  wasm_permission="Everybody"
+fi
+jq -r ".app_state.wasm.params.code_upload_access.permission |= \"${wasm_permission}\"" $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
 
 $CHAIN_BIN tendermint show-node-id

--- a/contrib/local/setup.sh
+++ b/contrib/local/setup.sh
@@ -54,13 +54,14 @@ sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $HOME/.persistenceCor
 sed -i 's/index_all_keys = false/index_all_keys = true/g' $HOME/.persistenceCore/config/config.toml
 
 echo "Update genesis.json file with updated local params"
-jq -r '.app_state.staking.params.unbonding_time |= "30s"' $HOME/.persistenceCore/config/genesis.json > /tmp/trash/genesis.json; mv /tmp/trash/genesis.json $HOME/.persistenceCore/config/genesis.json
-jq -r '.app_state.slashing.params.downtime_jail_duration |= "6s"' $HOME/.persistenceCore/config/genesis.json > /tmp/trash/genesis.json; mv /tmp/trash/genesis.json $HOME/.persistenceCore/config/genesis.json
-jq -r '.app_state.gov.deposit_params.max_deposit_period |= "30s"' $HOME/.persistenceCore/config/genesis.json > /tmp/trash/genesis.json; mv /tmp/trash/genesis.json $HOME/.persistenceCore/config/genesis.json
-jq -r '.app_state.gov.deposit_params.min_deposit[0].amount |= "10"' $HOME/.persistenceCore/config/genesis.json > /tmp/trash/genesis.json; mv /tmp/trash/genesis.json $HOME/.persistenceCore/config/genesis.json
-jq -r '.app_state.gov.voting_params.voting_period |= "30s"' $HOME/.persistenceCore/config/genesis.json > /tmp/trash/genesis.json; mv /tmp/trash/genesis.json $HOME/.persistenceCore/config/genesis.json
-jq -r '.app_state.gov.tally_params.quorum |= "0.000000000000000000"' $HOME/.persistenceCore/config/genesis.json > /tmp/trash/genesis.json; mv /tmp/trash/genesis.json $HOME/.persistenceCore/config/genesis.json
-jq -r '.app_state.gov.tally_params.threshold |= "0.000000000000000000"' $HOME/.persistenceCore/config/genesis.json > /tmp/trash/genesis.json; mv /tmp/trash/genesis.json $HOME/.persistenceCore/config/genesis.json
-jq -r '.app_state.gov.tally_params.veto_threshold |= "0.000000000000000000"' $HOME/.persistenceCore/config/genesis.json > /tmp/trash/genesis.json; mv /tmp/trash/genesis.json $HOME/.persistenceCore/config/genesis.json
+jq -r '.app_state.staking.params.unbonding_time |= "30s"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
+jq -r '.app_state.slashing.params.downtime_jail_duration |= "6s"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
+jq -r '.app_state.gov.deposit_params.max_deposit_period |= "30s"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
+jq -r '.app_state.gov.deposit_params.min_deposit[0].amount |= "10"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
+jq -r '.app_state.gov.voting_params.voting_period |= "30s"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
+jq -r '.app_state.gov.tally_params.quorum |= "0.000000000000000000"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
+jq -r '.app_state.gov.tally_params.threshold |= "0.000000000000000000"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
+jq -r '.app_state.gov.tally_params.veto_threshold |= "0.000000000000000000"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
+jq -r '.app_state.wasm.params.code_upload_access.permission |= "Nobody"' $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
 
 $CHAIN_BIN tendermint show-node-id


### PR DESCRIPTION
## 1. Overview

Add docker based testing for persistence chain in `contrib/local`. Create statically linked go binaries with libwasm.

## 2. Implementation details
* Create dockerfile of persistenceCore with statically (with libwasm) created binary for persisteceCore
* Push docker image `persistenceone/persistencecore:latest` with `contrib/local` scripts
* Add docker setup and exec commands for interactions with persistenceCore and wasm in `contrib/local`

## 3. How to test/use
* `cd contrib/local`
* `make docker-setup`: This will pull the docker image and start the container and run the full setup, run the docker container in the background
* `make docker-exec`: Open bash script into the container. Then can run `make run-gov-contract` commands from within the container.
* Run `make docker-clean` to stop the running container

## 4. Checklist
- [x] Does the Readme need to be updated?

## 5. Limitations (optional)
* This does not have upgrade in place
* Since we dont store the state, once the background container is stopped then will loose all data
* Can load a volume into the docker container

## 6. Future Work (optional)
* Create statically linked binaries for next releases as well