### PR TITLE
wasm disable instantiate

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -14,6 +14,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/CosmWasm/wasmd/x/wasm"
+	wasmClient "github.com/CosmWasm/wasmd/x/wasm/client"
+	wasmKeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
@@ -98,10 +102,6 @@ import (
 	ibcTypes "github.com/cosmos/ibc-go/v3/modules/core/05-port/types"
 	ibcHost "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 	ibcKeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
-	"github.com/CosmWasm/wasmd/x/wasm"
-	wasmClient "github.com/CosmWasm/wasmd/x/wasm/client"
-	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	wasmKeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	"github.com/gogo/protobuf/grpc"
 	"github.com/gorilla/mux"
 	"github.com/rakyll/statik/fs"
@@ -233,9 +233,9 @@ type Application struct {
 	HalvingKeeper      halving.Keeper
 	WasmKeeper         wasm.Keeper
 
-	moduleManager      *module.Manager
-	configurator       module.Configurator
-	simulationManager  *module.SimulationManager
+	moduleManager     *module.Manager
+	configurator      module.Configurator
+	simulationManager *module.SimulationManager
 
 	// make scoped keepers public for test purposes
 	ScopedIBCKeeper      capabilityKeeper.ScopedKeeper
@@ -287,12 +287,12 @@ func NewApplication(
 	transientStoreKeys := sdk.NewTransientStoreKeys(paramsTypes.TStoreKey)
 	memoryKeys := sdk.NewMemoryStoreKeys(capabilityTypes.MemStoreKey)
 
-	app := &Application {
-		BaseApp: baseApp,
-		legacyAmino: legacyAmino,
-		applicationCodec: applicationCodec,
+	app := &Application{
+		BaseApp:           baseApp,
+		legacyAmino:       legacyAmino,
+		applicationCodec:  applicationCodec,
 		interfaceRegistry: interfaceRegistry,
-		keys: keys,
+		keys:              keys,
 	}
 
 	app.ParamsKeeper = initParamsKeeper(
@@ -740,6 +740,7 @@ func NewApplication(
 			// here when migrating (is it is not customized).
 			params := app.WasmKeeper.GetParams(ctx)
 			params.CodeUploadAccess = wasmTypes.AllowNobody
+			params.InstantiateDefaultPermission = wasmTypes.AccessTypeNobody
 			app.WasmKeeper.SetParams(ctx, params)
 
 			return newVM, nil

--- a/contrib/local/Makefile
+++ b/contrib/local/Makefile
@@ -32,8 +32,11 @@ run-contract:
 run-gov-contract:
 	$(MAKE) .bash SCRIPT_FILE=gov_contract.sh
 
-run-cw20-test:
+run-cw20-base:
 	$(MAKE) .bash SCRIPT_FILE=test_cw20.sh
+
+run-cw20-govinit:
+	$(MAKE) .bash SCRIPT_FILE=test_cw20_govinit.sh
 
 run-test:
 	$(MAKE) .bash SCRIPT_FILE=test.sh
@@ -56,12 +59,18 @@ DOCKER_ENV ?= \
 	-e CHAIN_DIR=/opt \
 	-e CHAIN_BIN=/usr/bin/persistenceCore \
 	-e WASM_PERMISSIONLESS=$(WASM_PERMISSIONLESS)
+DOCKER_PORTS ?= \
+	-p 127.0.0.1:1317:1317 \
+	-p 127.0.0.1:26656-26657:26656-26657 \
+	-p 127.0.0.1:9090:9090
 
 docker-setup: docker-clean
 	$(DOCKER) run --rm -d \
 		--name=$(DOCKER_CONTAINER) \
-		$(DOCKER_ENV) \
+		$(DOCKER_ENV) $(DOCKER_PORTS) \
 		$(DOCKER_IMAGE_NAME):$(DOCKER_TAG_NAME) make
+	echo "Waiting for the docker to start...."
+	sleep 10
 
 docker-exec:
 	$(DOCKER) exec -it $(DOCKER_CONTAINER) /bin/bash

--- a/contrib/local/Makefile
+++ b/contrib/local/Makefile
@@ -4,7 +4,7 @@ CHAIN_DIR ?= /tmp/trash
 CHAIN_BIN ?= ./../../build/persistenceCore
 WASM_PERMISSIONLESS ?= false
 
-all: clean setup start
+all: docker-clean clean setup start
 
 .bash:
 	CHAIN_ID=$(CHAIN_ID) \

--- a/contrib/local/Makefile
+++ b/contrib/local/Makefile
@@ -32,6 +32,9 @@ run-contract:
 run-gov-contract:
 	$(MAKE) .bash SCRIPT_FILE=gov_contract.sh
 
+run-cw20-test:
+	$(MAKE) .bash SCRIPT_FILE=test_cw20.sh
+
 run-test:
 	$(MAKE) .bash SCRIPT_FILE=test.sh
 

--- a/contrib/local/README.md
+++ b/contrib/local/README.md
@@ -2,22 +2,28 @@
 
 Scripts for running local net locally
 
+## Prerequiest
+For any of the types bellow, need to build the local clients
+* From root dir `persistenceCore/`
+* Run `make build`: This will create the binary at `./build/persistenceCore`
+
 ## In system
-* First build the binaries with `make build` in root directory.
 * Change directory into `cd contrib/local`
 * `make`: Runs cleanup, `setup.sh` script, start node.
   * Initiate the gensis file
   * Override the config params
 * Above command will be blocking, hence advised to run in a separate terminal
 * Run test commands
-  * `make run-gov-contract`: Create proposal via proposal, vote on the proposal, and initiate the contract, run test commands
+  * `make run-cw20-govinit`: Create cw20 contract in wasm via a proposal, instantiate the contract via proposal as well, run test commands
 * `make clean` cleanup
 
 ## In Docker
-* `make docker-setup`: Pull the core image, and run `make` command, run in background
-* `make docker-exec`: Open and bash shell into the background container, can run further test commands there
-  * `make run-gov-contract` inside the container
+* Change directory into `cd contrib/local`
+* `make docker-setup`: Pull the core image, and run `make` command, run in background, export ports to local host
+* Then you can connect to the chain running in docker at localhost
+* Run `make run-gov-contract` from `contrib/local` file on local system
 * `make docker-clean`: Cleanup the containers after testing
+* Optionally: `make docker-exec`: Open and bash shell into the background container, can run further test commands there
 
 ## Permissionless wasm
 By default the chain runs with wasm as a permissioned module where all the contracts
@@ -35,3 +41,8 @@ WASM_PERMISSIONLESS=true make docker-setup
 
 With this we start the container such that the wasm module runns in permissionless fashion. For testing,
 run `make run-contract` for permissionless contract testing.
+
+Commands we can run with permissionless wasm are
+* `make run-contract`
+* `make run-gov-contract`
+* `make run-cw20-base`

--- a/contrib/local/setup.sh
+++ b/contrib/local/setup.sh
@@ -69,6 +69,8 @@ if [ $WASM_PERMISSIONLESS == "true" ]
 then
   wasm_permission="Everybody"
 fi
+
 jq -r ".app_state.wasm.params.code_upload_access.permission |= \"${wasm_permission}\"" $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
+jq -r ".app_state.wasm.params.instantiate_default_permission |= \"${wasm_permission}\"" $HOME/.persistenceCore/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/.persistenceCore/config/genesis.json
 
 $CHAIN_BIN tendermint show-node-id

--- a/contrib/local/test_cw20.sh
+++ b/contrib/local/test_cw20.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
+
 set -o errexit -o nounset -o pipefail -eu
 
 DIR="/tmp/test-contracts"
 mkdir -p $DIR
 
+VAL1_KEY=$($CHAIN_BIN keys show -a val1 --keyring-backend test)
+TEST1_KEY=$($CHAIN_BIN keys show -a test1 --keyring-backend test)
+TEST2_KEY=$($CHAIN_BIN keys show -a test2 --keyring-backend test)
+
 echo "-----------------------"
-echo "## Add new CosmWasm contract via gov proposal"
-wget "https://github.com/CosmWasm/wasmd/raw/14688c09855ee928a12bcb7cd102a53b78e3cbfb/x/wasm/keeper/testdata/hackatom.wasm" -q -O $DIR/hackatom.wasm
-VAL1_KEY=$($CHAIN_BIN keys show -a val1)
-RESP=$($CHAIN_BIN tx gov submit-proposal wasm-store "$DIR/hackatom.wasm" \
-  --title "hackatom" \
-  --description "hackatom test contact" \
+echo "## Add cw CosmWasm contract via gov proposal"
+wget "https://github.com/CosmWasm/cw-plus/releases/download/v0.13.4/cw20_base.wasm" -q -O $DIR/cw20_base.wasm
+
+RESP=$($CHAIN_BIN tx gov submit-proposal wasm-store "$DIR/cw20_base.wasm" \
+  --title "Add cw20_base" \
+  --description "cw20_base contact" \
   --deposit 10000stake \
   --run-as $VAL1_KEY \
   --instantiate-everybody "true" \
@@ -40,37 +45,52 @@ sleep 40
 $CHAIN_BIN q wasm list-code -o json | jq
 
 CODE_ID=$($CHAIN_BIN q wasm list-code -o json | jq -r ".code_infos[-1].code_id")
+CODE_ID=1
 
 echo "-----------------------"
 echo "## Create new contract instance"
-INIT="{\"verifier\":\"$($CHAIN_BIN keys show val1 -a --keyring-backend test)\", \"beneficiary\":\"$($CHAIN_BIN keys show test1 -a)\"}"
-$CHAIN_BIN tx wasm instantiate "$CODE_ID" "$INIT" --admin="$($CHAIN_BIN keys show val1 -a --keyring-backend test)" \
-  --from val1 --amount "10000stake" --label "local0.1.0" --gas-adjustment 1.5 --fees "10000stake" \
+INIT=$(cat <<EOF
+{
+  "name": "My first token",
+  "symbol": "FRST",
+  "decimals": 6,
+  "initial_balances": [{
+    "address": "$TEST1_KEY",
+    "amount": "123456789000"
+  }]
+}
+EOF
+)
+$CHAIN_BIN tx wasm instantiate "$CODE_ID" "$INIT" --admin="$TEST1_KEY" \
+  --from $TEST1_KEY --amount "10000stake" --label "First Coin" --gas-adjustment 1.5 --fees "10000stake" \
   --gas "auto" -y --chain-id $CHAIN_ID -b block -o json | jq
 
 CONTRACT=$($CHAIN_BIN query wasm list-contract-by-code "$CODE_ID" -o json | jq -r '.contracts[-1]')
 echo "* Contract address: $CONTRACT"
 
-echo "### Query all"
-RESP=$($CHAIN_BIN query wasm contract-state all "$CONTRACT" -o json)
-echo "$RESP" | jq
-echo "### Query smart"
-$CHAIN_BIN query wasm contract-state smart "$CONTRACT" '{"verifier":{}}' -o json | jq
-echo "### Query raw"
-KEY=$(echo "$RESP" | jq -r ".models[0].key")
-$CHAIN_BIN query wasm contract-state raw "$CONTRACT" "$KEY" -o json | jq
+echo "### Query test balance: expected balance: "
+$CHAIN_BIN query wasm contract-state smart $CONTRACT "{\"balance\":{\"address\":\"$TEST1_KEY\"}}"
+echo "### Query non balance: expected balance: "
+$CHAIN_BIN query wasm contract-state smart $CONTRACT "{\"balance\":{\"address\":\"$TEST2_KEY\"}}"
 
 echo "-----------------------"
 echo "## Execute contract $CONTRACT"
-MSG='{"release":{}}'
-$CHAIN_BIN tx wasm execute "$CONTRACT" "$MSG" \
+TRANSFER=$(cat <<EOF
+{
+  "transfer": {
+    "recipient": "$TEST2_KEY",
+    "amount": "987654321"
+  }
+}
+EOF
+)
+
+echo $TRANSFER | jq
+$CHAIN_BIN tx wasm execute $CONTRACT "$TRANSFER" \
   --from val1 --gas-adjustment 1.5 --fees "10000stake" \
   --gas "auto" -y --chain-id $CHAIN_ID -b block -o json | jq
 
-echo "-----------------------"
-echo "## Set new admin"
-echo "### Query old admin: $($CHAIN_BIN q wasm contract "$CONTRACT" -o json | jq -r '.contract_info.admin')"
-echo "### Update contract"
-$CHAIN_BIN tx wasm set-contract-admin "$CONTRACT" "$($CHAIN_BIN keys show test1 -a)" \
-  --from val1 --gas-adjustment 1.5 --gas "auto" --fees "10000stake" -y --chain-id $CHAIN_ID -b block -o json | jq
-echo "### Query new admin: $($CHAIN_BIN q wasm contract "$CONTRACT" -o json | jq -r '.contract_info.admin')"
+echo "### Query balance after transfer: expected balance: "
+$CHAIN_BIN query wasm contract-state smart $CONTRACT "{\"balance\":{\"address\":\"$TEST1_KEY\"}}"
+echo "### Query non balance after transfer: expected balance: "
+$CHAIN_BIN query wasm contract-state smart $CONTRACT "{\"balance\":{\"address\":\"$TEST2_KEY\"}}"

--- a/contrib/local/test_cw20.sh
+++ b/contrib/local/test_cw20.sh
@@ -87,7 +87,7 @@ EOF
 
 echo $TRANSFER | jq
 $CHAIN_BIN tx wasm execute $CONTRACT "$TRANSFER" \
-  --from val1 --gas-adjustment 1.5 --fees "10000stake" \
+  --from $TEST1_KEY --gas-adjustment 1.5 --fees "10000stake" \
   --gas "auto" -y --chain-id $CHAIN_ID -b block -o json | jq
 
 echo "### Query balance after transfer: expected balance: "

--- a/contrib/local/test_cw20_govinit.sh
+++ b/contrib/local/test_cw20_govinit.sh
@@ -18,12 +18,12 @@ RESP=$($CHAIN_BIN tx gov submit-proposal wasm-store "$DIR/cw20_base.wasm" \
   --description "cw20_base contact" \
   --deposit 10000stake \
   --run-as $VAL1_KEY \
-  --instantiate-everybody "true" \
+  --instantiate-nobody "true" \
   --keyring-backend test \
   --from val1 --gas auto --fees 10000stake -y \
   --chain-id $CHAIN_ID \
   -b block -o json --gas-adjustment 1.5)
-echo "$RESP"
+echo "$RESP" | jq
 PROPOSAL_ID=$(echo "$RESP" | jq -r '.logs[0].events[] | select(.type == "submit_proposal") | .attributes[] | select(.key == "proposal_id") | .value')
 
 echo "### Query proposal prevote"
@@ -47,7 +47,7 @@ $CHAIN_BIN q wasm list-code -o json | jq
 CODE_ID=$($CHAIN_BIN q wasm list-code -o json | jq -r ".code_infos[-1].code_id")
 
 echo "-----------------------"
-echo "## Create new contract instance"
+echo "## Create new contract instance via gov"
 INIT=$(cat <<EOF
 {
   "name": "My first token",
@@ -60,9 +60,40 @@ INIT=$(cat <<EOF
 }
 EOF
 )
-$CHAIN_BIN tx wasm instantiate "$CODE_ID" "$INIT" --admin="$TEST1_KEY" \
-  --from $TEST1_KEY --amount "10000stake" --label "First Coin" --gas-adjustment 1.5 --fees "10000stake" \
-  --gas "auto" -y --chain-id $CHAIN_ID -b block -o json | jq
+echo "### Initiate contract via gov proposal"
+RESP=$($CHAIN_BIN tx gov submit-proposal instantiate-contract $CODE_ID "$INIT" \
+  --admin="$TEST1_KEY" \
+  --from $TEST1_KEY \
+  --deposit 10000stake \
+  --label "First Coin" \
+  --title "FirstCoin" \
+  --description "First cw20 token created via contract" \
+  --gas-adjustment 1.5 \
+  --fees "10000stake" \
+  --gas "auto" \
+  --run-as $VAL1_KEY \
+  -y --chain-id $CHAIN_ID -b block -o json)
+
+echo "$RESP" | jq
+PROPOSAL_ID=$(echo "$RESP" | jq -r '.logs[0].events[] | select(.type == "submit_proposal") | .attributes[] | select(.key == "proposal_id") | .value')
+
+echo "### Query proposal prevote"
+$CHAIN_BIN q gov proposal $PROPOSAL_ID -o json | jq
+
+echo "### Vote proposal"
+$CHAIN_BIN tx gov vote $PROPOSAL_ID yes --from val1 --yes --chain-id $CHAIN_ID \
+    --fees 500stake --gas auto --gas-adjustment 1.5 -b block -o json | jq
+$CHAIN_BIN tx gov vote $PROPOSAL_ID yes --from test1 --yes --chain-id $CHAIN_ID \
+    --fees 500stake --gas auto --gas-adjustment 1.5 -b block -o json | jq
+$CHAIN_BIN tx gov vote $PROPOSAL_ID yes --from test2 --yes --chain-id $CHAIN_ID \
+    --fees 500stake --gas auto --gas-adjustment 1.5 -b block -o json | jq
+
+echo "### Query proposal postvote"
+$CHAIN_BIN q gov proposal $PROPOSAL_ID -o json | jq
+
+echo "### Waiting for voting period..."
+sleep 40
+$CHAIN_BIN q wasm list-code -o json | jq
 
 CONTRACT=$($CHAIN_BIN query wasm list-contract-by-code "$CODE_ID" -o json | jq -r '.contracts[-1]')
 echo "* Contract address: $CONTRACT"


### PR DESCRIPTION
## 1. Overview

Set `instantiate_default_permission` to allow Nobody to instantiate a contract. All instantiation will have to go though a gov proposal.

## 2. Implementation details
* Set `instantiate_default_permission` to `AccessTypeNobody`
* Follow: https://docs.cosmwasm.com/tutorials/governance/#available-configurations

## 3. How to test/use
* Build binary with `make build`
* `cd contrib/local`
* run `make`, this will start the container, run this in a separate terminal
* run `make run-cw20-govinit` to be able to run the whole process
* Note `make run-gov-contract` will fail since it tries to set `--instantiate-everybody "true"`, this is an expected error

## 4. Checklist

- [ ] Does the Readme need to be updated?
