### PR TITLE
Update constants.go

### DIFF
--- a/app/constants.go
+++ b/app/constants.go
@@ -13,7 +13,7 @@ const (
 	Name             = "PersistenceCore"
 	Bech32MainPrefix = "persistence"
 	UpgradeName      = "v3"
-	CoinType         = 750
+	CoinType         = 118
 	Purpose          = 44
 
 	Bech32PrefixAccAddr  = Bech32MainPrefix


### PR DESCRIPTION
## 1. Overview

Change coin-type to 118

## 2. Implementation details

default `persistenceCore keys ___` arguements will create wallets with coin-type 118.
users can still continue to create wallets with 750 coin-type using flag, `--coin-type 750`

## 3. How to test/use

`persistenceCore keys add test --recover` 
and
`persistenceCore keys add test2 --recover --coin-type 118` should give same result
while
`persistenceCore keys add test3 --recover --coin-type 750` should give different result
## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ x ] Does the Readme need to be updated?

## 6. Future Work (optional)

- discontinue persistence ledger app support and use cosmos-ledger-app