### PR TITLE
chore: version fix and trimpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COMMIT := $(shell git log -1 --format='%H')
 
 # don't override user values
 ifeq (,$(VERSION))
-  VERSION := $(shell git describe --exact-match 2>/dev/null)
+  VERSION := $(shell git describe --tags --exact-match)
   # if VERSION is empty, then populate it with branch's name and raw commit hash
   ifeq (,$(VERSION))
     VERSION := $(BRANCH)-$(COMMIT)
@@ -76,6 +76,10 @@ ifeq (rocksdb,$(findstring rocksdb,$(build_tags)))
 endif
 
 BUILD_FLAGS += -ldflags '${ldflags}' -tags "${build_tags}"
+# check for nostrip option
+ifeq (,$(findstring nostrip,$(BUILD_OPTIONS)))
+  BUILD_FLAGS += -trimpath
+endif
 
 GOBIN = $(shell go env GOPATH)/bin
 GOARCH = $(shell go env GOARCH)


### PR DESCRIPTION
## 1. Overview
-->
Makefile will use tags if possible else use branch-commit format for version.

## 2. Implementation details.

its mostly a fix for existing checks

## 3. How to test/use

`persistenceCore version`

## 4. Checklist

`persistenceCore version`
