### PR TITLE
fix: read persistent command flags.

### DIFF
--- a/cmd/persistenceCore/cmd/root.go
+++ b/cmd/persistenceCore/cmd/root.go
@@ -60,7 +60,12 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		Use:   "persistenceCore",
 		Short: "Persistence Hub Node Daemon (server)",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			initClientCtx, err := config.ReadFromClientConfig(initClientCtx)
+			initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			initClientCtx, err = config.ReadFromClientConfig(initClientCtx)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## 1. Overview

keys failed to create with --home flag

## 2. Implementation details

read persistent flags  in cmd/root.go main command.

## 3. How to test/use
```
persistenceCore keys delete  testkey --keyring-backend test --home .xyz -y
persistenceCore keys add testkey --keyring-backend test --home .xyz
```

