### PR TITLE
set srvCfg.IAVLDisableFastNode = false

### DIFF
--- a/cmd/persistenceCore/cmd/root.go
+++ b/cmd/persistenceCore/cmd/root.go
@@ -35,6 +35,8 @@ import (
 
 	"github.com/persistenceOne/persistenceCore/v3/app"
 	"github.com/persistenceOne/persistenceCore/v3/app/params"
+
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 )
 
 const flagInvalidCheckPeriod = "invalid-check-period"
@@ -74,13 +76,68 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 				return err
 			}
 
-			return server.InterceptConfigsPreRunHandler(cmd, "", nil)
+			customAppTemplate, customAppConfig := initAppConfig()
+
+			return server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig)
 		},
 	}
 
 	initRootCmd(rootCmd, encodingConfig)
 
 	return rootCmd, encodingConfig
+}
+
+// initAppConfig helps to override default appConfig template and configs.
+// return "", nil if no custom configuration is required for the application.
+func initAppConfig() (string, interface{}) {
+	// The following code snippet is just for reference.
+
+	// WASMConfig defines configuration for the wasm module.
+	type WASMConfig struct {
+		// This is the maximum sdk gas (wasm and storage) that we allow for any x/wasm "smart" queries
+		QueryGasLimit uint64 `mapstructure:"query_gas_limit"`
+
+		// Address defines the gRPC-web server to listen on
+		LruSize uint64 `mapstructure:"lru_size"`
+	}
+
+	type CustomAppConfig struct {
+		serverconfig.Config
+
+		WASM WASMConfig `mapstructure:"wasm"`
+	}
+
+	// Optionally allow the chain developer to overwrite the SDK's default
+	// server config.
+	srvCfg := serverconfig.DefaultConfig()
+	// The SDK's default minimum gas price is set to "" (empty value) inside
+	// app.toml. If left empty by validators, the node will halt on startup.
+	// However, the chain developer can set a default app.toml value for their
+	// validators here.
+	//
+	// In summary:
+	// - if you leave srvCfg.MinGasPrices = "", all validators MUST tweak their
+	//   own app.toml config,
+	// - if you set srvCfg.MinGasPrices non-empty, validators CAN tweak their
+	//   own app.toml to override, or use this default value.
+	//
+	// In simapp, we set the min gas prices to 0.
+	srvCfg.MinGasPrices = "0stake"
+	// srvCfg.BaseConfig.IAVLDisableFastNode = true // disable fastnode by default
+
+	srvCfg.IAVLDisableFastNode = false
+
+	customAppConfig := CustomAppConfig{
+		Config: *srvCfg,
+		WASM: WASMConfig{
+			LruSize:       1,
+			QueryGasLimit: 300000,
+		},
+	}
+
+	customAppTemplate := serverconfig.DefaultConfigTemplate
+
+	return customAppTemplate, customAppConfig
 }
 
 // setCfg params at the package state
@@ -255,6 +312,8 @@ func (ac appCreator) newApp(
 		baseapp.SetSnapshotStore(snapshotStore),
 		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
 		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),
+		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
+		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagIAVLFastNode))),
 	)
 }
 


### PR DESCRIPTION
## 1. Overview

I set IAVLDisableFastNode to be false in customAppConfig

## 2. Implementation details

Add `initAppConfig()` in root.go
Use customAppTemplate, customAppConfig in `server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig)`

## 3. How to test/use

<!-- How can people test/use this? -->

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->