### PR TITLE
fix local chain init

### DIFF
--- a/contrib/local/setup.sh
+++ b/contrib/local/setup.sh
@@ -62,7 +62,7 @@ sed -i -e 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $HOME/$CHAIN_DATA_
 sed -i -e 's/index_all_keys = false/index_all_keys = true/g' $HOME/$CHAIN_DATA_DIR/config/config.toml
 
 echo "Update genesis.json file with updated local params"
-sed -i -e "s/stake/$DENOM/g" $HOME/$CHAIN_DATA_DIR/config/genesis.json
+sed -i -e "s/pstake/1PROTECTED1/g; s/restake/2PROTECTED2/g; s/unstake/3PROTECTED3/g; s/stake/$DENOM/g; s/1PROTECTED1/pstake/g; s/2PROTECTED2/restake/g; s/3PROTECTED3/unstake/g" $HOME/$CHAIN_DATA_DIR/config/genesis.json
 
 jq -r '.app_state.staking.params.unbonding_time |= "30s"' $HOME/$CHAIN_DATA_DIR/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/$CHAIN_DATA_DIR/config/genesis.json
 jq -r '.app_state.slashing.params.downtime_jail_duration |= "6s"' $HOME/$CHAIN_DATA_DIR/config/genesis.json > /tmp/genesis.json; mv /tmp/genesis.json $HOME/$CHAIN_DATA_DIR/config/genesis.json


### PR DESCRIPTION
## 1. Overview

<!-- What are you changing, removing, or adding in this review? -->
Currently `pstake`, `restake`, `unstake` words are being changed to `puxprt`, `reuxprt`, `unuxprt` due to the denom changing sed.

## 2. Implementation details

<!-- Describe the implementation (highlights only) as well as design rationale. -->
Protected above words for the replacement.

## 3. How to test/use

<!-- How can people test/use this? -->
Init local chain.

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->