### PR TITLE
add pstake upgrade instructions.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -805,15 +805,55 @@ func NewApplication(
 	app.UpgradeKeeper.SetUpgradeHandler(
 		UpgradeName,
 		func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			ctx.Logger().Info("start to run module migrations...")
+			ctx.Logger().Info("start to run pstake migration...")
 
-			// RunMigrations twice is just a way to make auth module's migrates after staking
+			//add more upgrade instructions
+			// send stk/uatom to persistence1zl42hd5h9c7z4ej43fhss9nvgm6nuad0js8z6n (for https://www.mintscan.io/cosmos/txs/DE691EC8EBB5A79E2AB421291660111E893823CA0CC9EBDED5E3C72B503067C3 sending amount to reward address)
+			// at c_value 0.999142233051758540 = 44961400stk/uatom (`curl -X GET -H "Content-Type: application/json" -H "x-cosmos-block-height: 8650000" 'https://rest.core.persistence.one/pstake/lscosmos/v1beta1/c_value'`)
+			PstakeUpgradeV6 := func(ctx sdk.Context, k lscosmoskeeper.Keeper) {
+				atomTVU := k.GetDepositAccountAmount(ctx).
+					Add(k.GetIBCTransferTransientAmount(ctx)).
+					Add(k.GetDelegationTransientAmount(ctx)).
+					Add(k.GetStakedAmount(ctx)).
+					Add(k.GetHostDelegationAccountAmount(ctx))
+
+				mintedAmount := k.GetMintedAmount(ctx)
+				mintDenom := k.GetHostChainParams(ctx).MintDenom
+				if atomTVU.LTE(mintedAmount) {
+					return
+				}
+				toNewMint := atomTVU.Sub(mintedAmount)
+				if ctx.ChainID() == "core-1" {
+					if toNewMint.GT(sdk.NewInt(44961400)) {
+						mischiefUserAddress := sdk.MustAccAddressFromBech32("persistence1zl42hd5h9c7z4ej43fhss9nvgm6nuad0js8z6n")
+						toSendUser := sdk.NewInt(44961400)
+						err := k.MintTokens(ctx, sdk.NewCoin(mintDenom, toSendUser), mischiefUserAddress)
+						if err != nil {
+							k.Logger(ctx).Error("Failed to mint and send 44961400stk/uatom to persistence1zl42hd5h9c7z4ej43fhss9nvgm6nuad0js8z6n")
+						}
+						pstakeFeeAddress := sdk.MustAccAddressFromBech32(k.GetHostChainParams(ctx).PstakeParams.PstakeFeeAddress)
+						remainingAmount := toNewMint.Sub(toSendUser)
+						err = k.MintTokens(ctx, sdk.NewCoin(mintDenom, remainingAmount), pstakeFeeAddress)
+						if err != nil {
+							k.Logger(ctx).Error("Failed to mint and send remainingAmount to pstakeFeeAddress")
+						}
+					}
+				}
+				if ctx.ChainID() == "test-core-1" {
+					pstakeFeeAddress := sdk.MustAccAddressFromBech32(k.GetHostChainParams(ctx).PstakeParams.PstakeFeeAddress)
+					err := k.MintTokens(ctx, sdk.NewCoin(mintDenom, toNewMint), pstakeFeeAddress)
+					if err != nil {
+						k.Logger(ctx).Error("Failed to mint and send toNewMint to pstakeFeeAddress")
+					}
+				}
+			}
+			PstakeUpgradeV6(ctx, app.LSCosmosKeeper)
+
+			ctx.Logger().Info("start to run module migrations...")
 			newVM, err := app.moduleManager.RunMigrations(ctx, app.configurator, fromVM)
 			if err != nil {
 				return nil, err
 			}
-			//add more upgrade instructions
-
 			return newVM, nil
 		},
 	)
@@ -825,8 +865,7 @@ func NewApplication(
 	//
 	//if upgradeInfo.Name == UpgradeName && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 	//	storeUpgrades := storetypes.StoreUpgrades{
-	//		Added: []string{icacontrollertypes.SubModuleName, epochstypes.ModuleName,
-	//			interchainquerytypes.ModuleName, lscosmostypes.ModuleName},
+	//		Added: []string{},
 	//	}
 	//
 	//	// configure store loader that checks if version == upgradeHeight and applies store upgrades


### PR DESCRIPTION
## 1. Overview
- adds upgrade/fork instructions for pstake. (resetting c_value to 1), and distributing tokens w.r.t those.

## 2. Implementation details

- calculates diff between already staked atoms and minted supply, mints the diff, distributed the diff to sender acc and fee address.

## 3. How to test/use

- by upgrade testing

