### PR TITLE
bump v2.0.0 of persistence-sdk and pstake-native

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/cosmos/ibc-go/v4 v4.3.0
 	github.com/gogo/protobuf v1.3.3
 	github.com/gorilla/mux v1.8.0
-	github.com/persistenceOne/persistence-sdk/v2 v2.0.0-rc0
-	github.com/persistenceOne/pstake-native/v2 v2.0.0-rc0
+	github.com/persistenceOne/persistence-sdk/v2 v2.0.0
+	github.com/persistenceOne/pstake-native/v2 v2.0.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -738,10 +738,10 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
-github.com/persistenceOne/persistence-sdk/v2 v2.0.0-rc0 h1:nzMcu1CGw/cAl3Gc5rxHdpAkK8TMEeag0BlGBM3Zj/4=
-github.com/persistenceOne/persistence-sdk/v2 v2.0.0-rc0/go.mod h1:suGw84bvEWW4ZKSGyCvv4bqzo1yIl5Z3bIVUg1bEKw8=
-github.com/persistenceOne/pstake-native/v2 v2.0.0-rc0 h1:dVOCC+r4PnWl8eTYTTThLF0yEZHI6lYk0CUWSHc3TGQ=
-github.com/persistenceOne/pstake-native/v2 v2.0.0-rc0/go.mod h1:3KfSf2lzq022kIwy6WRNokr297KSbGpPQWcypMiU34Y=
+github.com/persistenceOne/persistence-sdk/v2 v2.0.0 h1:OaNYUZnVdoEetgyuUzo1/1k4hXv3MjELmqeiyXNPDgU=
+github.com/persistenceOne/persistence-sdk/v2 v2.0.0/go.mod h1:suGw84bvEWW4ZKSGyCvv4bqzo1yIl5Z3bIVUg1bEKw8=
+github.com/persistenceOne/pstake-native/v2 v2.0.0 h1:ISgOL1/WGxTzpp5D2yWFDgjSViNTCT9TfVCWTUyZY0E=
+github.com/persistenceOne/pstake-native/v2 v2.0.0/go.mod h1:3KfSf2lzq022kIwy6WRNokr297KSbGpPQWcypMiU34Y=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp0hoxKjt1H5pDo6utceo3dQVK3I5XQ=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=


### PR DESCRIPTION
## 1. Overview

version bump
- persistence-sdk v2.0.0
- pstake-native v2.0.0
