### PR TITLE
fix: don't remove staking from wasm supportedFeatures

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -410,7 +410,7 @@ func NewAppKeeper(
 
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
-	supportedFeatures := "iterator,stargate"
+	supportedFeatures := "iterator,staking,stargate"
 	wasmOpts = append(wasmbindings.RegisterStargateQueries(*bApp.GRPCQueryRouter(), appCodec), wasmOpts...)
 	wasmKeeper := wasm.NewKeeper(
 		appCodec,


### PR DESCRIPTION
reverts an accidental change made in https://github.com/persistenceOne/persistenceCore/commit/660d643d5e84f1e1b5cc7644144ff50497c9d4ee

fixes issue with statesync:

```
> failed to restore snapshot err="extension wasm restore: processing snapshot item: Error calling the VM: Error during static Wasm validation: Wasm contract requires unavailable capabilities: {\"staking\"}: create wasm contract failed"
```