### PR TITLE
chore: bump persistence-sdk to v2.1.0-rc3

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -54,12 +54,12 @@ import (
 	"github.com/persistenceOne/persistenceCore/v8/app/keepers"
 	appparams "github.com/persistenceOne/persistenceCore/v8/app/params"
 	"github.com/persistenceOne/persistenceCore/v8/app/upgrades"
-	v8 "github.com/persistenceOne/persistenceCore/v8/app/upgrades/v8"
+	v8rc4 "github.com/persistenceOne/persistenceCore/v8/app/upgrades/v8rc4"
 )
 
 var (
 	DefaultNodeHome string
-	Upgrades        = []upgrades.Upgrade{v8.Upgrade}
+	Upgrades        = []upgrades.Upgrade{v8rc4.Upgrade}
 	ModuleBasics    = module.NewBasicManager(keepers.AppModuleBasics...)
 )
 

--- a/app/upgrades/v8rc4/constants.go
+++ b/app/upgrades/v8rc4/constants.go
@@ -1,0 +1,20 @@
+package v8rc4
+
+import (
+	store "github.com/cosmos/cosmos-sdk/store/types"
+
+	"github.com/persistenceOne/persistenceCore/v8/app/upgrades"
+)
+
+const (
+	// UpgradeName defines the on-chain upgrade name.
+	UpgradeName = "v8-rc4"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added: []string{},
+	},
+}

--- a/app/upgrades/v8rc4/upgrades.go
+++ b/app/upgrades/v8rc4/upgrades.go
@@ -1,0 +1,17 @@
+package v8rc4
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/persistenceOne/persistenceCore/v8/app/upgrades"
+)
+
+func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx.Logger().Info("running upgrade handler")
+
+		return args.ModuleManager.RunMigrations(ctx, args.Configurator, vm)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cosmos/ibc-go/v6 v6.1.0
 	github.com/gogo/protobuf v1.3.3
 	github.com/gorilla/mux v1.8.0
-	github.com/persistenceOne/persistence-sdk/v2 v2.1.0-rc2
+	github.com/persistenceOne/persistence-sdk/v2 v2.1.0-rc3
 	github.com/persistenceOne/pstake-native/v2 v2.1.0-rc0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rakyll/statik v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -775,8 +775,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
-github.com/persistenceOne/persistence-sdk/v2 v2.1.0-rc2 h1:5Erv5ECMoaBHA0YmcXD7My/fRzYzqRcoPCSZNdHjDoA=
-github.com/persistenceOne/persistence-sdk/v2 v2.1.0-rc2/go.mod h1:17uPaWchEBtSa5pQ6EdHZDbFh3ppiZNZjMHg+kiJtcE=
+github.com/persistenceOne/persistence-sdk/v2 v2.1.0-rc3 h1:r6zdcgSjkg+8yQO9IgXb350uMh9qsZiaFXlLFcSO11A=
+github.com/persistenceOne/persistence-sdk/v2 v2.1.0-rc3/go.mod h1:b144ZSaf3BYb+OYIZUYMtsx+9Cv49xlIYuZPUSDq1NA=
 github.com/persistenceOne/pstake-native/v2 v2.1.0-rc0 h1:eKH60IMLVEl39SWu6QEB7adBm0c/up808Y0w+tpJleg=
 github.com/persistenceOne/pstake-native/v2 v2.1.0-rc0/go.mod h1:77iJIcyM5qb2D787OUKRNUfZzhj/T5c9674AWR+etxc=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=


### PR DESCRIPTION
## 1. Overview

Bumps persistence-sdk https://github.com/persistenceOne/persistence-sdk/releases/tag/v2.1.0-rc3 
has breaking consensus changes, needs testnet upgrade