### PR TITLE
chore: update ibc-go dep to v4.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.19
 require (
 	github.com/CosmWasm/wasmd v0.30.0
 	github.com/cosmos/cosmos-sdk v0.45.14
-	github.com/cosmos/ibc-go/v4 v4.3.0
+	github.com/cosmos/ibc-go/v4 v4.3.1
 	github.com/gogo/protobuf v1.3.3
 	github.com/gorilla/mux v1.8.0
-	github.com/persistenceOne/persistence-sdk/v2 v2.0.0
+	github.com/persistenceOne/persistence-sdk/v2 v2.0.1
 	github.com/persistenceOne/pstake-native/v2 v2.0.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rakyll/statik v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cosmos/iavl v0.19.5 h1:rGA3hOrgNxgRM5wYcSCxgQBap7fW82WZgY78V9po/iY=
 github.com/cosmos/iavl v0.19.5/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
-github.com/cosmos/ibc-go/v4 v4.3.0 h1:yOzVsyZzsv4XPBux8gq+D0LhZn45yGWKjvT+6Vyo5no=
-github.com/cosmos/ibc-go/v4 v4.3.0/go.mod h1:CcLvIoi9NNtIbNsxs4KjBGjYhlwqtsmXy1AKARKiMzQ=
+github.com/cosmos/ibc-go/v4 v4.3.1 h1:xbg0CaCdxK3lvgGvSaI91ROOLd7s30UqEcexH6Ba4Ys=
+github.com/cosmos/ibc-go/v4 v4.3.1/go.mod h1:89E+K9CxpkS/etLEcG026jPM/RSnVMcfesvRYp/0aKI=
 github.com/cosmos/interchain-accounts v0.2.4 h1:7UrroFQsCRSp17980mk6anx4YteveIJVkU+a0wlsHQI=
 github.com/cosmos/ledger-cosmos-go v0.12.2 h1:/XYaBlE2BJxtvpkHiBm97gFGSGmYGKunKyF3nNqAXZA=
 github.com/cosmos/ledger-cosmos-go v0.12.2/go.mod h1:ZcqYgnfNJ6lAXe4HPtWgarNEY+B74i+2/8MhZw4ziiI=
@@ -738,8 +738,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
-github.com/persistenceOne/persistence-sdk/v2 v2.0.0 h1:OaNYUZnVdoEetgyuUzo1/1k4hXv3MjELmqeiyXNPDgU=
-github.com/persistenceOne/persistence-sdk/v2 v2.0.0/go.mod h1:suGw84bvEWW4ZKSGyCvv4bqzo1yIl5Z3bIVUg1bEKw8=
+github.com/persistenceOne/persistence-sdk/v2 v2.0.1 h1:YSze3egRhqGGOGdNqkYHrEq6o+t7tPbBAdd2zQKA7SU=
+github.com/persistenceOne/persistence-sdk/v2 v2.0.1/go.mod h1:Vj9u+GN1nRgpKe58J60AOI8GwTU2NDnxC5yZPt8dNCs=
 github.com/persistenceOne/pstake-native/v2 v2.0.0 h1:ISgOL1/WGxTzpp5D2yWFDgjSViNTCT9TfVCWTUyZY0E=
 github.com/persistenceOne/pstake-native/v2 v2.0.0/go.mod h1:3KfSf2lzq022kIwy6WRNokr297KSbGpPQWcypMiU34Y=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=


### PR DESCRIPTION
Rolling update for huckleberry security advisory: https://github.com/cosmos/ibc-go/releases/tag/v4.3.1

See also `persistence-sdk` v2.0.1 https://github.com/persistenceOne/persistence-sdk/releases/tag/v2.0.1