### PR TITLE
feat: add POB module for skip-mev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,18 +13,20 @@
   - CLI: `add-genesis-account`, `gentx`, `add-genesis-account`, `collect-gentxs` and others are now under `genesis` command as parent
   - CLI: `--broadcast-mode block` was removed. You need to query the result for a TX with `persistenceCore q tx <hash>` instead
   - ...add more?
-- Upgrades persistence-sdk from `v2.0.1` to `vx.x.x` which
-  - add POB for MEV
-  - adds IBC hooks
-  - adds PFM module
-  - adds Oracle module (not in use for now)
-- Upgrades pstake-native from `v2.0.0` to `vx.x.x` which
-  - adds new module liquidstakeibc
-  - deprecates lscosmos module
+- Upgrades persistence-sdk from `v2.0.1` to `vx.x.x`
+- Upgrades pstake-native from `v2.0.0` to `vx.x.x`
 - Adds wasm-bindings
+- Modules integrated from `persistence-sdk`
+  - IBC hooks
+  - PFM
+  - Oracle
+- Modules integrated from `pstake-native`
+  - liquidstakeibc - this deprecates `lscosmos` module
+- Integrated POB module for MEV - disabled aution txs for now.
 
 ### Changes
 
+- ([#207](https://github.com/persistenceOne/persistenceCore/pull/207)) adds POB module for skip-mev
 - ([#205](https://github.com/persistenceOne/persistenceCore/pull/205)) bump cosmos-sdk to `v0.47.3-lsm` and deps (includes new modules: IBC hooks, PFM, liquidstakeibc)
 - ([#198](https://github.com/persistenceOne/persistenceCore/pull/198), [#206](https://github.com/persistenceOne/persistenceCore/pull/206)) starship e2e upgrade tests
 - ([#184](https://github.com/persistenceOne/persistenceCore/pull/184)) removal of unused exposer

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -84,6 +84,8 @@ import (
 	"github.com/persistenceOne/pstake-native/v2/x/lscosmos"
 	lscosmoskeeper "github.com/persistenceOne/pstake-native/v2/x/lscosmos/keeper"
 	lscosmostypes "github.com/persistenceOne/pstake-native/v2/x/lscosmos/types"
+	builderkeeper "github.com/skip-mev/pob/x/builder/keeper"
+	buildertypes "github.com/skip-mev/pob/x/builder/types"
 	routerkeeper "github.com/strangelove-ventures/packet-forward-middleware/v7/router/keeper"
 	routertypes "github.com/strangelove-ventures/packet-forward-middleware/v7/router/types"
 
@@ -131,6 +133,7 @@ type AppKeepers struct {
 	ConsensusParamsKeeper *consensusparamskeeper.Keeper
 	GroupKeeper           *groupkeeper.Keeper
 	RouterKeeper          *routerkeeper.Keeper
+	BuilderKeeper         *builderkeeper.Keeper
 
 	// Modules
 	TransferModule             ibctransfer.AppModule
@@ -529,6 +532,17 @@ func NewAppKeeper(
 		appKeepers.IBCKeeper.ChannelKeeper,
 	)
 
+	builderKeeper := builderkeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[buildertypes.StoreKey],
+		appKeepers.AccountKeeper,
+		appKeepers.BankKeeper,
+		appKeepers.DistributionKeeper,
+		appKeepers.StakingKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	appKeepers.BuilderKeeper = &builderKeeper
+
 	var icaHostStack ibctypes.IBCModule
 	icaHostStack = icahost.NewIBCModule(*appKeepers.ICAHostKeeper)
 	icaHostStack = ibcfee.NewIBCMiddleware(icaHostStack, *appKeepers.IBCFeeKeeper)
@@ -623,6 +637,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	paramsKeeper.Subspace(group.ModuleName)
 	paramsKeeper.Subspace(ibchookstypes.ModuleName)
 	paramsKeeper.Subspace(routertypes.ModuleName)
+	paramsKeeper.Subspace(buildertypes.ModuleName)
 
 	return paramsKeeper
 }

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -32,6 +32,7 @@ import (
 	oracletypes "github.com/persistenceOne/persistence-sdk/v2/x/oracle/types"
 	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	lscosmostypes "github.com/persistenceOne/pstake-native/v2/x/lscosmos/types"
+	buildertypes "github.com/skip-mev/pob/x/builder/types"
 	routertypes "github.com/strangelove-ventures/packet-forward-middleware/v7/router/types"
 )
 
@@ -42,6 +43,7 @@ func (appKeepers *AppKeepers) GenerateKeys() {
 		authtypes.StoreKey,
 		authzkeeper.StoreKey,
 		banktypes.StoreKey,
+		buildertypes.StoreKey,
 		capabilitytypes.StoreKey,
 		consensusparamstypes.StoreKey,
 		crisistypes.StoreKey,

--- a/app/keepers/modules.go
+++ b/app/keepers/modules.go
@@ -39,6 +39,7 @@ import (
 	"github.com/persistenceOne/persistence-sdk/v2/x/oracle"
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc"
 	"github.com/persistenceOne/pstake-native/v2/x/lscosmos"
+	buildermodule "github.com/skip-mev/pob/x/builder"
 	"github.com/strangelove-ventures/packet-forward-middleware/v7/router"
 )
 
@@ -87,4 +88,5 @@ var AppModuleBasics = []module.AppModuleBasic{
 	groupmodule.AppModuleBasic{},
 	ibchooks.AppModuleBasic{},
 	router.AppModuleBasic{},
+	buildermodule.AppModuleBasic{},
 }

--- a/app/modules.go
+++ b/app/modules.go
@@ -58,6 +58,8 @@ import (
 	"github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc"
 	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 	lscosmostypes "github.com/persistenceOne/pstake-native/v2/x/lscosmos/types"
+	"github.com/skip-mev/pob/x/builder"
+	buildertypes "github.com/skip-mev/pob/x/builder/types"
 	"github.com/strangelove-ventures/packet-forward-middleware/v7/router"
 	routertypes "github.com/strangelove-ventures/packet-forward-middleware/v7/router/types"
 
@@ -85,6 +87,7 @@ var ModuleAccountPermissions = map[string][]string{
 	liquidstakeibctypes.ModuleName:                {authtypes.Minter, authtypes.Burner},
 	liquidstakeibctypes.DepositModuleAccount:      nil,
 	liquidstakeibctypes.UndelegationModuleAccount: {authtypes.Burner},
+	buildertypes.ModuleName:                       nil,
 }
 
 var receiveAllowedMAcc = map[string]bool{
@@ -135,6 +138,7 @@ func appModules(
 		app.LSCosmosModule,
 		liquidstakeibc.NewAppModule(*app.LiquidStakeIBCKeeper),
 		oracle.NewAppModule(appCodec, *app.OracleKeeper, app.AccountKeeper, app.BankKeeper),
+		builder.NewAppModule(appCodec, *app.BuilderKeeper),
 		crisis.NewAppModule(app.CrisisKeeper, skipGenesisInvariants, app.GetSubspace(crisistypes.ModuleName)), // always be last to make sure that it checks for all invariants and not only part of them
 	}
 }
@@ -175,6 +179,7 @@ func orderBeginBlockers() []string {
 		group.ModuleName,
 		paramstypes.ModuleName,
 		vestingtypes.ModuleName,
+		buildertypes.ModuleName,
 		consensusparamtypes.ModuleName,
 		halving.ModuleName,
 		ibchookstypes.ModuleName,
@@ -222,6 +227,7 @@ func orderEndBlockers() []string {
 		liquidstakeibctypes.ModuleName,
 		oracletypes.ModuleName,
 		lscosmostypes.ModuleName,
+		buildertypes.ModuleName,
 	}
 }
 
@@ -265,5 +271,6 @@ func orderInitGenesis() []string {
 		liquidstakeibctypes.ModuleName,
 		oracletypes.ModuleName,
 		lscosmostypes.ModuleName,
+		buildertypes.ModuleName,
 	}
 }

--- a/app/upgrades/v8/constants.go
+++ b/app/upgrades/v8/constants.go
@@ -9,6 +9,7 @@ import (
 	ibchookstypes "github.com/persistenceOne/persistence-sdk/v2/x/ibc-hooks/types"
 	oracletypes "github.com/persistenceOne/persistence-sdk/v2/x/oracle/types"
 	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
+	buildertypes "github.com/skip-mev/pob/x/builder/types"
 	routertypes "github.com/strangelove-ventures/packet-forward-middleware/v7/router/types"
 
 	"github.com/persistenceOne/persistenceCore/v8/app/upgrades"
@@ -32,6 +33,7 @@ var Upgrade = upgrades.Upgrade{
 			consensusparamstypes.ModuleName,
 			ibchookstypes.StoreKey,
 			routertypes.ModuleName,
+			buildertypes.ModuleName,
 		},
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/persistenceOne/pstake-native/v2 v2.2.0-rc3
 	github.com/prometheus/client_golang v1.15.0
 	github.com/rakyll/statik v0.1.7
+	github.com/skip-mev/pob v1.0.0
 	github.com/spf13/cast v1.5.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
@@ -148,7 +149,6 @@ require (
 	github.com/rs/cors v1.8.3 // indirect
 	github.com/rs/zerolog v1.29.1 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
-	github.com/skip-mev/pob v1.0.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
@@ -196,4 +196,5 @@ replace (
 	github.com/CosmWasm/wasmd => github.com/persistenceOne/wasmd v0.0.0-20230615215703-e2229415de74
 	github.com/cosmos/cosmos-sdk => github.com/persistenceOne/cosmos-sdk v0.0.0-20230611231946-790aaf168429
 	github.com/cosmos/ibc-go/v7 => github.com/persistenceOne/ibc-go/v7 v7.0.0-rc0.0.20230612095033-b776ca4647aa
+	github.com/skip-mev/pob => github.com/persistenceOne/pob v1.0.0-lsm
 )

--- a/go.sum
+++ b/go.sum
@@ -982,6 +982,8 @@ github.com/persistenceOne/ibc-go/v7 v7.0.0-rc0.0.20230612095033-b776ca4647aa h1:
 github.com/persistenceOne/ibc-go/v7 v7.0.0-rc0.0.20230612095033-b776ca4647aa/go.mod h1:DK8bzoAukxOGX1KiPSRWjx0VrDOerWP7HkWlxfoF2Js=
 github.com/persistenceOne/persistence-sdk/v2 v2.1.0-rc3.0.20230623125729-42659cad73c9 h1:TW964PN89m9GfejHjcU4kAH48rsrI5x2kKNFqj/x9qs=
 github.com/persistenceOne/persistence-sdk/v2 v2.1.0-rc3.0.20230623125729-42659cad73c9/go.mod h1:yyCsctYwwyh8uE0MaEgO0oNm/QT6ugd5vtVRx8ZXRLI=
+github.com/persistenceOne/pob v1.0.0-lsm h1:8S5YUpbuurj4AnzLqeeBan9sEDB/OL2IARh6AizWkl4=
+github.com/persistenceOne/pob v1.0.0-lsm/go.mod h1:Gg9vkg9SvYIjwJAAosypoa3PSwpErX+ZGw8eoI0Hops=
 github.com/persistenceOne/pstake-native/v2 v2.2.0-rc3 h1:RbLIMTWQQ9R7KepV1UmUpZrQHPe8Op9abT3iz3nFb4I=
 github.com/persistenceOne/pstake-native/v2 v2.2.0-rc3/go.mod h1:t+oa6RERNcz9DzZ5NvLtX/G/xyblRaetSTHd2/PljJ0=
 github.com/persistenceOne/wasmd v0.0.0-20230615215703-e2229415de74 h1:2nJoLNlR7Js52DROrtHmcjy67daobm00yhrRGvXFME8=
@@ -1080,8 +1082,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/skip-mev/pob v1.0.0 h1:4SNdMv8SoQZNmd0abKmbTJ0NoXECGpgUd7V75CmX6Wo=
-github.com/skip-mev/pob v1.0.0/go.mod h1:QLDYHDF8kWT02OonjZh3b8Xpz/48Savah+9zRMrs4Bc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION
## 1. Overview

Add POB module for skip MEV

## 2. Implementation details

- Includes Auction mempool and their custom Ante decorator from v1.0.0
- Disables Auction by setting `MaxBundleSize` to`0` in upgrade handler (to be enabled later)