### PR TITLE
Refactor Makefile build flags and add Heighliner config

### DIFF
--- a/chains.yaml
+++ b/chains.yaml
@@ -1,0 +1,13 @@
+# This file is used to create docker images using the heighliner binary.
+# see: https://github.com/strangelove-ventures/heighliner
+
+- name: persistence
+  github-organization: persistenceOne
+  github-repo: persistenceCore
+  dockerfile: cosmos
+  build-target: make install
+  binaries:
+    - /go/bin/persistenceCore
+  build-env:
+    - LEDGER_ENABLED=false
+    - BUILD_TAGS=muslc


### PR DESCRIPTION
Refactor `Makefile` to be aligned with rest cosmos projects, most importantly:
* fix static build when doing `make install`, some linking args (LDFLAGS) were eaten
* remove unused commands, especially under "Documentation" section, those don't belong to Documentation anyway.
* added linting commands, similar to upstream cosmos sdk
* fixing the static build was needed to facilitate building using common pipelines such as [Heighliner](https://github.com/strangelove-ventures/heighliner)

Also adds a config for **Heighliner** and corresponding makefile commands.

TODO: future improvements to Makefile should include sims running 