### PR TITLE
fix: remove ibcfee from ica controller stack

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -554,7 +554,6 @@ func NewAppKeeper(
 	// Information will flow: ibc-port -> icaController -> lscosmos.
 	var icaControllerStack ibctypes.IBCModule = liquidStakeIBCModule
 	icaControllerStack = icacontroller.NewIBCMiddleware(icaControllerStack, *appKeepers.ICAControllerKeeper)
-	icaControllerStack = ibcfee.NewIBCMiddleware(icaControllerStack, *appKeepers.IBCFeeKeeper)
 
 	var wasmStack ibctypes.IBCModule
 	wasmStack = wasm.NewIBCHandler(appKeepers.WasmKeeper, appKeepers.IBCKeeper.ChannelKeeper, appKeepers.IBCFeeKeeper)


### PR DESCRIPTION
## 1. Overview

Removed ibcfee from ica controller stack.
This caused failure in ICA channel creation, where channel version was sent with `{"fee_version":"ics29-1"}`.

the error log from relayer
> rpc error: code = Unknown desc = rpc error: code = Unknown desc = failed to execute message; message index: 1: channel open try callback failed: cannot unmarshal ICS-27 interchain accounts metadata: unknown data type [cosmos/ibc-go/v4@v4.2.0/modules/apps/27-interchain-accounts/host/keeper/handshake.go:39] With gas wanted: '0' and gas used: '147268' : unknown request