### PR TITLE
Add E2E testing using interchaintest into CI

### DIFF
--- a/.github/workflows/e2e-testing.yaml
+++ b/.github/workflows/e2e-testing.yaml
@@ -1,0 +1,77 @@
+---
+name: End to End Tests
+
+on:
+  pull_request:
+
+env:
+  TAR_PATH: heighliner.tar
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Docker image
+        uses: strangelove-ventures/heighliner-build-action@v0.0.3
+        with:
+          registry: # empty registry, image only shared for e2e testing
+          tag: local # emulate local environment for consistency in interchaintest cases
+          tar-export-path: ${{ env.TAR_PATH }} # export a tarball that can be uploaded as an artifact for the e2e jobs
+          platform: linux/amd64 # test runner architecture only
+          git-ref: ${{ github.head_ref }} # source code ref
+
+          # Heighliner chains.yaml config
+          chain: persistence
+          dockerfile: cosmos
+          build-target: make install
+          binaries: |
+            - /go/bin/persistenceCore
+          build-env: |
+            - LEDGER_ENABLED=false
+            - BUILD_TAGS=muslc
+
+        # Use github actions artifacts for temporary storage of the docker image tarball
+      - name: Publish Tarball as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: persistence-docker-image
+          path: ${{ env.TAR_PATH }}
+
+  e2e-tests:
+    needs: build-docker
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            # names of `make` commands to run tests
+            test:
+              - "ictest-basic"
+              - "ictest-pob"
+              - "ictest-upgrade"
+              - "ictest-ibc"
+              - "ictest-ibchooks"
+              - "ictest-pfm"
+        fail-fast: false
+
+    steps:
+      # Load the docker image tarball from github actions artifacts and run tests (one runner per test due to matrix)
+      - name: Download Tarball Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: persistence-docker-image
+
+      - name: Load Docker Image
+        run: docker image load -i ${{ env.TAR_PATH }}
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.0
+
+      - name: checkout chain
+        uses: actions/checkout@v3
+
+      - name: run test
+        run: make ${{ matrix.test }}


### PR DESCRIPTION
## 1. Overview

This is a CI workflow `End to End Tests` that creates a test matrix for interchaintest suite. It replaces workflow `E2E Upgrade tests` that used Starship and therefore disabled.

## 2. Implementation details

1. Implement YAML config that builds local branch docker image and submits as an artefact to the next stage
2. The next stage performs steps - 1 per each `ictest-*` makefile action

NOTE:  `E2E Upgrade tests` has been manually disabled in the settings of this repo. The starship version can be run locally using [act](https://github.com/nektos/act)

## 3. How to test/use

This runs automatically on every PR.
