### PR TITLE
set MinInitialDepositRatio to 25% + cleanup param subspaces

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -638,12 +638,8 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	paramsKeeper.Subspace(wasm.ModuleName)
 	paramsKeeper.Subspace(icacontrollertypes.SubModuleName)
 	paramsKeeper.Subspace(lscosmostypes.ModuleName)
-	paramsKeeper.Subspace(interchainquerytypes.ModuleName)
 	paramsKeeper.Subspace(oracletypes.ModuleName)
-	paramsKeeper.Subspace(group.ModuleName)
-	paramsKeeper.Subspace(ibchookstypes.ModuleName)
 	paramsKeeper.Subspace(packetforwardtypes.ModuleName)
-	paramsKeeper.Subspace(buildertypes.ModuleName)
 
 	return paramsKeeper
 }

--- a/app/upgrades/v8/legacy_subspaces.go
+++ b/app/upgrades/v8/legacy_subspaces.go
@@ -1,6 +1,8 @@
 package v8
 
 import (
+	"fmt"
+
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -14,9 +16,14 @@ import (
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	packetforwardtypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/types"
 	icacontrollertypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/types"
 	icahosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
+	"github.com/persistenceOne/persistence-sdk/v2/x/halving"
+	oracletypes "github.com/persistenceOne/persistence-sdk/v2/x/oracle/types"
+	lscosmostypes "github.com/persistenceOne/pstake-native/v2/x/lscosmos/types"
 )
 
 func getLegacySubspaces(paramsKeeper *paramskeeper.Keeper) paramstypes.Subspace {
@@ -42,18 +49,22 @@ func getLegacySubspaces(paramsKeeper *paramskeeper.Keeper) paramstypes.Subspace 
 			keyTable = govv1.ParamKeyTable() //nolint:staticcheck
 		case crisistypes.ModuleName:
 			keyTable = crisistypes.ParamKeyTable() //nolint:staticcheck
-		// ibc types
-		case ibctransfertypes.ModuleName:
-			keyTable = ibctransfertypes.ParamKeyTable()
-		case icahosttypes.SubModuleName:
-			keyTable = icahosttypes.ParamKeyTable()
-		case icacontrollertypes.SubModuleName:
-			keyTable = icacontrollertypes.ParamKeyTable()
 		// wasm
 		case wasmtypes.ModuleName:
 			keyTable = wasmtypes.ParamKeyTable() //nolint:staticcheck
-		default:
+
+		// these modules have not migrated away from x/params
+		case halving.DefaultParamspace,
+			ibcexported.ModuleName,
+			ibctransfertypes.ModuleName,
+			icacontrollertypes.SubModuleName,
+			icahosttypes.SubModuleName,
+			lscosmostypes.ModuleName,
+			oracletypes.ModuleName,
+			packetforwardtypes.ModuleName:
 			continue
+		default:
+			panic(fmt.Sprintf("param key table not set for subspace: %s", subspace.Name()))
 		}
 
 		if !subspace.HasKeyTable() {

--- a/app/upgrades/v8/upgrades.go
+++ b/app/upgrades/v8/upgrades.go
@@ -87,6 +87,12 @@ func disableMEVAuction(ctx sdk.Context, keepers *keepers.AppKeepers) error {
 	return keepers.BuilderKeeper.SetParams(ctx, builderParams)
 }
 
+func setMinInitialDepositRatio(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	govParams := keepers.GovKeeper.GetParams(ctx)
+	govParams.MinInitialDepositRatio = "0.25"
+	return keepers.GovKeeper.SetParams(ctx, govParams)
+}
+
 func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.UpgradeHandler {
 	baseAppLegacySS := getLegacySubspaces(args.Keepers.ParamsKeeper)
 
@@ -171,7 +177,10 @@ func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.Upgrade
 			return nil, err
 		}
 
-		// TODO(ajeet): do we need to set gov -> MinInitialDepositRatio? (default is 0 -> disabled)
+		ctx.Logger().Info("setting x/gov min initial deposit ratio to 25%")
+		if err = setMinInitialDepositRatio(ctx, args.Keepers); err != nil {
+			return nil, err
+		}
 
 		return newVersionMap, nil
 	}

--- a/app/upgrades/v8/upgrades.go
+++ b/app/upgrades/v8/upgrades.go
@@ -94,8 +94,6 @@ func setMinInitialDepositRatio(ctx sdk.Context, keepers *keepers.AppKeepers) err
 }
 
 func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.UpgradeHandler {
-	baseAppLegacySS := getLegacySubspaces(args.Keepers.ParamsKeeper)
-
 	return func(ctx sdk.Context, plan upgradetypes.Plan, versionMap module.VersionMap) (module.VersionMap, error) {
 		ctx.Logger().Info("running upgrade handler")
 
@@ -134,13 +132,11 @@ func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.Upgrade
 		// -- nothing --
 
 		// sdk v46-to-v47
+		// initialize param subspaces for params migration
+		baseAppLegacySS := getLegacySubspaces(args.Keepers.ParamsKeeper)
 		// Migrate Tendermint consensus parameters from x/params module to a dedicated x/consensus module.
 		ctx.Logger().Info("migrating tendermint x/consensus params")
 		baseapp.MigrateParams(ctx, baseAppLegacySS, args.Keepers.ConsensusParamsKeeper)
-
-		// Note: this migration is optional,
-		// You can include x/gov proposal migration documented in [UPGRADING.md](https://github.com/cosmos/cosmos-sdk/blob/main/UPGRADING.md)
-		// TODO(ajeet): do we need this optional migration?
 
 		ctx.Logger().Info("running module manager migrations")
 

--- a/starship/v7v8/params.go
+++ b/starship/v7v8/params.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibcclienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	exported "github.com/cosmos/ibc-go/v7/modules/core/exported"
@@ -34,4 +35,9 @@ func (s *TestSuite) VerifyParams() {
 	ibcClientParams, err := ibcclienttypes.NewQueryClient(client).ClientParams(ctx, &ibcclienttypes.QueryClientParamsRequest{})
 	s.Require().NoError(err)
 	s.Require().Contains(ibcClientParams.Params.AllowedClients, exported.Localhost)
+
+	s.T().Log("verify gov MinInitialDepositParam")
+	govParams, err := govtypes.NewQueryClient(client).Params(ctx, &govtypes.QueryParamsRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal("0.25", govParams.Params.MinInitialDepositRatio)
 }


### PR DESCRIPTION
## 1. Overview

- sets `MinInitialDepositRatio` to 25% + adds a check in e2e test for this
- cleanup params subspaces that weren't being used
- explicitly skip subspaces that don't need to be set in upgrade handler
