### PR TITLE
set LSM params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,14 @@
 - Upgrades persistence-sdk from `v2.0.1` to `vx.x.x`
 - Upgrades pstake-native from `v2.0.0` to `vx.x.x`
 - Adds wasm-bindings
-- Modules integrated from `persistence-sdk`
-  - IBC hooks
-  - PFM
-  - Oracle
-- Modules integrated from `pstake-native`
-  - liquidstakeibc - this deprecates `lscosmos` module
-- Integrated POB module for MEV - disabled aution txs for now.
+
+#### New Modules
+
+- IBC hooks
+- PFM (Packet forwarding middleware)
+- oracle - disabled for now
+- liquidstakeibc - this deprecates `lscosmos` module
+- POB for MEV - disabled auction txs for now
 
 #### MinCommissionRate
 
@@ -30,11 +31,23 @@
 
     > **Note**  
     > During upgrade,  
-    > Validator's `CommissionRate` will be set to 5%, if it is lower than the `MinCommissionRate` (i.e. 5%),  
-    > and Validator's `MaxCommissionRate` will be set to 10% (if lower than 10%) to give validator some margin to work with.
+    > Validator's `CommissionRate` will be set to `5%`, if it is lower than the `MinCommissionRate` (i.e. 5%),  
+    > and Validator's `MaxCommissionRate` will be set to `10%` (if lower than 10%) to give validator some margin to work with.
+
+#### MinInitialDepositRatio
+
+- `MinInitialDepositRatio` is set to `25%`, which means a proposal cannot be submitted with deposit lower than `25%` of `MinInitialDeposit`
+
+#### LSM Params
+
+- `ValidatorBondFactor` is set to `250`
+- `GlobalLiquidStakingCap` is set to `10%`
+- `ValidatorLiquidStakingCap` is set to `50%`
 
 ### Changes
 
+- ([#221](https://github.com/persistenceOne/persistenceCore/pull/221)) set LSM params
+- ([#219](https://github.com/persistenceOne/persistenceCore/pull/219)) set MinInitialDepositRatio to 25% + cleanup param subspaces
 - ([#211](https://github.com/persistenceOne/persistenceCore/pull/211)) Enfoce minimum limit for `CommissionRate` & `MaxCommissionRate`
 - ([#207](https://github.com/persistenceOne/persistenceCore/pull/207)) adds POB module for skip-mev
 - ([#205](https://github.com/persistenceOne/persistenceCore/pull/205)) bump cosmos-sdk to `v0.47.3-lsm` and deps (includes new modules: IBC hooks, PFM, liquidstakeibc)

--- a/app/upgrades/v8/upgrades.go
+++ b/app/upgrades/v8/upgrades.go
@@ -93,6 +93,14 @@ func setMinInitialDepositRatio(ctx sdk.Context, keepers *keepers.AppKeepers) err
 	return keepers.GovKeeper.SetParams(ctx, govParams)
 }
 
+func setLSMParams(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	stakingParams := keepers.StakingKeeper.GetParams(ctx)
+	stakingParams.ValidatorBondFactor = sdk.NewDec(250)
+	stakingParams.GlobalLiquidStakingCap = sdk.NewDecWithPrec(1, 1)    // 10%
+	stakingParams.ValidatorLiquidStakingCap = sdk.NewDecWithPrec(5, 1) // 50%
+	return keepers.StakingKeeper.SetParams(ctx, stakingParams)
+}
+
 func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, versionMap module.VersionMap) (module.VersionMap, error) {
 		ctx.Logger().Info("running upgrade handler")
@@ -175,6 +183,11 @@ func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.Upgrade
 
 		ctx.Logger().Info("setting x/gov min initial deposit ratio to 25%")
 		if err = setMinInitialDepositRatio(ctx, args.Keepers); err != nil {
+			return nil, err
+		}
+
+		ctx.Logger().Info("setting x/staking LSM params")
+		if err = setLSMParams(ctx, args.Keepers); err != nil {
 			return nil, err
 		}
 

--- a/starship/v7v8/params.go
+++ b/starship/v7v8/params.go
@@ -16,10 +16,13 @@ func (s *TestSuite) VerifyParams() {
 	ctx := context.Background()
 	client := s.GetChainClient("test-core-1").Client
 
-	s.T().Log("verify min commission rate")
+	s.T().Log("verify min commission rate & LSM params")
 	params, err := stakingtypes.NewQueryClient(client).Params(ctx, &stakingtypes.QueryParamsRequest{})
 	s.Require().NoError(err)
 	s.Require().Equal(sdk.NewDecWithPrec(5, 2), params.Params.MinCommissionRate)
+	s.Require().Equal(sdk.NewDec(250), params.Params.ValidatorBondFactor)
+	s.Require().Equal(sdk.NewDecWithPrec(1, 1), params.Params.GlobalLiquidStakingCap)
+	s.Require().Equal(sdk.NewDecWithPrec(5, 1), params.Params.ValidatorLiquidStakingCap)
 
 	s.T().Log("verify mev aution is disabled")
 	pobParams, err := buildertypes.NewQueryClient(client).Params(ctx, &buildertypes.QueryParamsRequest{})


### PR DESCRIPTION
## 1. Overview

Sets initial LSM params
- `ValidatorBondFactor` to `250`
- `GlobalLiquidStakingCap` to `10%`
- `ValidatorLiquidStakingCap` to `50%`
