### PR TITLE
fix: quickfix for build release stage - bin paths and static linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ release-build-platform:
 		DOCKER_TAG_NAME="release-$(PLATFORM)"
 	$(DOCKER) images
 	$(DOCKER) create -ti --name release-$(PLATFORM) $(DOCKER_IMAGE_NAME):release-$(PLATFORM)
-	$(DOCKER) cp release-$(PLATFORM):/usr/local/app/build/persistenceCore release/persistenceCore-$(VERSION)-linux-$(PLATFORM)
+	$(DOCKER) cp release-$(PLATFORM):/usr/local/app/bin/persistenceCore release/persistenceCore-$(VERSION)-linux-$(PLATFORM)
 	tar -zcvf release/persistenceCore-$(VERSION)-linux-$(PLATFORM).tar.gz release/persistenceCore-$(VERSION)-linux-$(PLATFORM)
 	-@$(DOCKER) rm -f release-$(PLATFORM)
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -23,6 +23,7 @@ _DOCKER_ARGS=\
 # Command for dockerization
 docker-build:
 	$(DOCKER) buildx build . \
+		--progress=plain \
 		$(DOCKER_BUILD_ARGS) \
 		-f docker/$(PROCESS)/$(DOCKER_FILE) \
 		-t $(DOCKER_IMAGE_NAME):$(DOCKER_TAG_NAME)

--- a/docker/persistencecore/Dockerfile
+++ b/docker/persistencecore/Dockerfile
@@ -27,11 +27,11 @@ COPY . .
 # Force it to use static lib (from above) not standard libgo_cosmwasm.so file
 RUN LEDGER_ENABLED=false BUILD_TAGS="muslc linkstatic" make build
 RUN echo "Ensuring binary is statically linked ..." \
-  && (file /usr/local/app/build/persistenceCore | grep "statically linked")
+  && (file /usr/local/app/bin/persistenceCore | grep "statically linked")
 
 FROM alpine:3.16
 
-COPY --from=go-builder /usr/local/app/build/persistenceCore /usr/bin/persistenceCore
+COPY --from=go-builder /usr/local/app/bin/persistenceCore /usr/bin/persistenceCore
 
 COPY contrib/local/ /opt/
 RUN chmod +x /opt/*.sh

--- a/docker/persistencecore/Dockerfile.release
+++ b/docker/persistencecore/Dockerfile.release
@@ -25,6 +25,6 @@ WORKDIR /usr/local/app
 COPY . .
 
 # Force it to use static lib (from above) not standard libgo_cosmwasm.so file
-RUN LEDGER_ENABLED=true BUILD_TAGS="muslc linkstatic" make build
+RUN LEDGER_ENABLED=true BUILD_TAGS="muslc linkstatic" LDFLAGS='-linkmode external -extldflags "-static"' make build
 RUN echo "Ensuring binary is statically linked ..." \
-  && (file /usr/local/app/build/persistenceCore | grep "statically linked")
+  && (file /usr/local/app/bin/persistenceCore | grep "statically linked")


### PR DESCRIPTION
Release builds fails due to makefile changes. This fix quickly unblocks the flow, while planned revision of makefiles and dockerfiles in this repo is planned for the next sprint.