### PR TITLE
Fix pointer to store upgrades inside loop

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -450,7 +450,8 @@ func (app *Application) setupUpgradeStoreLoaders() {
 
 	for _, upgrade := range Upgrades {
 		if upgradeInfo.Name == upgrade.UpgradeName {
-			app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &upgrade.StoreUpgrades))
+			storeUpgrades := upgrade.StoreUpgrades
+			app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 		}
 	}
 }


### PR DESCRIPTION
Due to how `for` loop works, if many upgrade plans are specified, the store upgrades are taken from the last one on the list, not the one matched by the upgrade name. To fix this, the copy of the object is made, before taking the pointer.