### PR TITLE
add whitelist for governance and pstake stargate queries

### DIFF
--- a/wasmbindings/stargate_whitelisted_queries.go
+++ b/wasmbindings/stargate_whitelisted_queries.go
@@ -6,7 +6,7 @@ import (
 
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	"github.com/cosmos/cosmos-sdk/codec"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	oracletypes "github.com/persistenceOne/persistence-sdk/v2/x/oracle/types"
 	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )

--- a/wasmbindings/stargate_whitelisted_queries.go
+++ b/wasmbindings/stargate_whitelisted_queries.go
@@ -6,7 +6,9 @@ import (
 
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/persistenceOne/persistence-sdk/v2/x/oracle/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	oracletypes "github.com/persistenceOne/persistence-sdk/v2/x/oracle/types"
+	liquidstakeibctypes "github.com/persistenceOne/pstake-native/v2/x/liquidstakeibc/types"
 )
 
 // StargateQueries is a map of stargate queries registered for the contract
@@ -14,7 +16,16 @@ var stargateWhitelistQueries sync.Map
 
 func init() {
 	// stargate queries available for the contract
-	setStargateWhitelistQuery("/persistence.oracle.v1beta1.Query/ExchangeRate", &types.QueryExchangeRateResponse{})
+	setStargateWhitelistQuery("/persistence.oracle.v1beta1.Query/ExchangeRate", &oracletypes.QueryExchangeRateResponse{})
+
+	// governance module
+	setStargateWhitelistQuery("/cosmos.gov.v1.Query/Proposal", &govtypes.QueryProposalResponse{})
+	setStargateWhitelistQuery("/cosmos.gov.v1.Query/Proposals", &govtypes.QueryProposalsResponse{})
+	setStargateWhitelistQuery("/cosmos.gov.v1.Query/Deposit", &govtypes.QueryDepositResponse{})
+	setStargateWhitelistQuery("/cosmos.gov.v1.Query/Params", &govtypes.QueryParamsResponse{})
+
+	// liquid staking module for exchange rate query from a contract
+	setStargateWhitelistQuery("/pstake.liquidstakeibc.v1beta1/ExchangeRate", &liquidstakeibctypes.QueryExchangeRateResponse{})
 }
 
 // setStargateWhitelistQuery stores the stargate queries.


### PR DESCRIPTION
## 1. Overview

<!-- What are you changing, removing, or adding in this review? -->

Added more queries to whitelist to allow querying gov module and pstake exchange rate from Cosmwasm Smart Contracts

## 2. Implementation details

<!-- Describe the implementation (highlights only) as well as design rationale. -->
Just added more queries to existing stargate whitelist

## 3. How to test/use

<!-- How can people test/use this? -->
Stargate query for Gov Proposal / Params and Pstake exchange rate from a contract should work. Tried with a Dexter contract on localnet.

## 4. Checklist

<!-- Checklist for PR author(s). -->

- [ ] Does the Readme need to be updated?
No.

## 5. Limitations (optional)

<!-- Describe any limitation of the capabilities listed in the Overview section. -->

## 6. Future Work (optional)

<!-- Describe follow up work, if any. -->