### PR TITLE
chore: create upgrade handler for v9.2.0

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -57,13 +57,12 @@ import (
 
 	"github.com/persistenceOne/persistenceCore/v9/app/keepers"
 	"github.com/persistenceOne/persistenceCore/v9/app/upgrades"
-	v9 "github.com/persistenceOne/persistenceCore/v9/app/upgrades/v9"
-	v9_1_0 "github.com/persistenceOne/persistenceCore/v9/app/upgrades/v9.1.0"
+	v9_2_0 "github.com/persistenceOne/persistenceCore/v9/app/upgrades/v9.2.0"
 )
 
 var (
 	DefaultNodeHome string
-	Upgrades        = []upgrades.Upgrade{v9.Upgrade, v9_1_0.Upgrade}
+	Upgrades        = []upgrades.Upgrade{v9_2_0.Upgrade}
 	ModuleBasics    = module.NewBasicManager(keepers.AppModuleBasics...)
 )
 

--- a/app/upgrades/v9.2.0/constants.go
+++ b/app/upgrades/v9.2.0/constants.go
@@ -1,0 +1,20 @@
+package v9_2_0
+
+import (
+	store "github.com/cosmos/cosmos-sdk/store/types"
+
+	"github.com/persistenceOne/persistenceCore/v9/app/upgrades"
+)
+
+const (
+	// UpgradeName defines the on-chain upgrade name.
+	UpgradeName = "v9.2.0"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added: []string{},
+	},
+}

--- a/app/upgrades/v9.2.0/upgrades.go
+++ b/app/upgrades/v9.2.0/upgrades.go
@@ -1,0 +1,17 @@
+package v9_2_0
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/persistenceOne/persistenceCore/v9/app/upgrades"
+)
+
+func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx.Logger().Info("running upgrade handler")
+
+		return args.ModuleManager.RunMigrations(ctx, args.Configurator, vm)
+	}
+}

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -29,9 +29,9 @@ func TestPersistenceUpgradeBasic(t *testing.T) {
 	var (
 		chainName            = "persistence"
 		upgradeRepo          = PersistenceCoreImage.Repository
-		initialVersion       = "v9.0.0"
+		initialVersion       = "v9.1.0"
 		upgradeBranchVersion = PersistenceCoreImage.Version
-		upgradeName          = "v9.1.0"
+		upgradeName          = "v9.2.0"
 	)
 
 	CosmosChainUpgradeTest(


### PR DESCRIPTION
## 1. Overview

<!-- What are you changing, removing, or adding in this review? -->
Creates upgrade handler for v9.2.0, removes v9.1.0, v9 from upgrade handler as no longer required.

to be reviewed/ merged post #239 
