### PR TITLE
fix: don't use consensus module in genesis import/export for now

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -248,7 +248,6 @@ func orderInitGenesis() []string {
 		paramstypes.ModuleName,
 		upgradetypes.ModuleName,
 		vestingtypes.ModuleName,
-		consensusparamtypes.ModuleName,
 		halving.ModuleName,
 		ibchookstypes.ModuleName,
 		packetforwardtypes.ModuleName,


### PR DESCRIPTION
## 1. Overview

Genesis export was failing:

```
panic: module consensus does not exist

goroutine 1 [running]:
github.com/cosmos/cosmos-sdk/types/module.(*Manager).ExportGenesisForModules(_, {{0x3463b60, 0x4b91ba0}, {0x34798e0, 0xc00c0b0080}, {{0x0, 0x0}, {0x0, 0x0}, 0xca6170, ...}, ...}, ...)
	github.com/cosmos/cosmos-sdk@v0.47.3/types/module/module.go:393 +0x4df
github.com/persistenceOne/persistenceCore/v9/app.(*Application).ExportAppStateAndValidators(0xc0005df2d0, 0x0, {0x4b91ba0, 0x0, 0x0}, {0x4b91ba0, 0x0, 0x0})
	github.com/persistenceOne/persistenceCore/v9/app/export.go:25 +0x1e7
```