### PR TITLE
increase metadata length limit to 5000

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -561,8 +561,7 @@ func NewAppKeeper(
 	}
 
 	govConfig := govtypes.DefaultConfig()
-	// Example of setting gov params:
-	// govConfig.MaxMetadataLen = 10000
+	govConfig.MaxMetadataLen = 5000
 
 	appKeepers.GovKeeper = govkeeper.NewKeeper(
 		appCodec,


### PR DESCRIPTION
## 1. Overview

Increased max limit for proposal metadata length.