### PR TITLE
add v10 upgrade to reduce blocksize

### DIFF
--- a/app/upgrades/v10/constants.go
+++ b/app/upgrades/v10/constants.go
@@ -1,0 +1,20 @@
+package v10
+
+import (
+	store "github.com/cosmos/cosmos-sdk/store/types"
+
+	"github.com/persistenceOne/persistenceCore/v9/app/upgrades"
+)
+
+const (
+	// UpgradeName defines the on-chain upgrade name.
+	UpgradeName = "v10"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added: []string{},
+	},
+}

--- a/app/upgrades/v10/upgrades.go
+++ b/app/upgrades/v10/upgrades.go
@@ -1,0 +1,24 @@
+package v10
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/persistenceOne/persistenceCore/v9/app/upgrades"
+)
+
+func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx.Logger().Info("running upgrade handler")
+
+		consensusParams, err := args.Keepers.ConsensusParamsKeeper.Get(ctx)
+		if err != nil {
+			panic(err)
+		}
+		consensusParams.Block.MaxBytes = 5242880
+		args.Keepers.ConsensusParamsKeeper.Set(ctx, consensusParams)
+
+		return args.ModuleManager.RunMigrations(ctx, args.Configurator, vm)
+	}
+}


### PR DESCRIPTION
## 1. Overview

Reduce block size as per https://forum.cosmos.network/t/amulet-security-advisory-for-cometbft-asa-2023-002/11604/1
Currently it reduces by half to ~5mb, recommended is 2mb

Creating a PR so that it does not fall through the cracks. 

## 2. Implementation details

add upgrade handler of v10

- have not changed the app imports to v10 as it is not necessary as of now, that can be done when v10 is fully planned. 