### PR TITLE
Bump ibc-apps to v7.2.0-lsm6 which contains a fix for pfm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,8 +203,8 @@ replace (
 replace (
 	github.com/CosmWasm/wasmd => github.com/persistenceOne/wasmd v0.40.2-lsm3
 	github.com/cosmos/cosmos-sdk => github.com/persistenceOne/cosmos-sdk v0.47.3-lsm5
-	github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7 => github.com/persistenceOne/ibc-apps/middleware/packet-forward-middleware/v7 v7.0.0-20231208060526-73231b958bd4
-	github.com/cosmos/ibc-apps/modules/ibc-hooks/v7 => github.com/persistenceOne/ibc-apps/modules/ibc-hooks/v7 v7.0.0-20231208060526-73231b958bd4
+	github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7 => github.com/persistenceOne/ibc-apps/middleware/packet-forward-middleware/v7 v7.0.0-20240109170424-f4a8f29910eb
+	github.com/cosmos/ibc-apps/modules/ibc-hooks/v7 => github.com/persistenceOne/ibc-apps/modules/ibc-hooks/v7 v7.0.0-20240109170424-f4a8f29910eb
 	github.com/cosmos/ibc-go/v7 => github.com/persistenceOne/ibc-go/v7 v7.2.0-lsm3
 	github.com/skip-mev/pob => github.com/persistenceOne/pob v1.0.3-lsm3
 )

--- a/go.sum
+++ b/go.sum
@@ -1012,10 +1012,10 @@ github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNc
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/persistenceOne/cosmos-sdk v0.47.3-lsm5 h1:z5k9M81ogHgaMyLck7GVzfdNYvn03ZTXsCpQDzy69eQ=
 github.com/persistenceOne/cosmos-sdk v0.47.3-lsm5/go.mod h1:4oxikyyHyEe1wlYQFMGITfW/r01wYtfj8yjwru7bSWE=
-github.com/persistenceOne/ibc-apps/middleware/packet-forward-middleware/v7 v7.0.0-20231208060526-73231b958bd4 h1:7HGqX27LtoKrbOHTI1ymyT0fAHHoSd+xfxGuI8KFJ2Y=
-github.com/persistenceOne/ibc-apps/middleware/packet-forward-middleware/v7 v7.0.0-20231208060526-73231b958bd4/go.mod h1:v+x4hTcShRZylXZNsK5zXFQ8QMV448rbIY4e9HDXBkY=
-github.com/persistenceOne/ibc-apps/modules/ibc-hooks/v7 v7.0.0-20231208060526-73231b958bd4 h1:vxJTAcApUh/pizcdEj6KFI5dv9KeiM2RGOggJz6y3k4=
-github.com/persistenceOne/ibc-apps/modules/ibc-hooks/v7 v7.0.0-20231208060526-73231b958bd4/go.mod h1:fbwFAk6oxuKiFvp5SLCItT34A1+F5LjGcMNOTuU8h4c=
+github.com/persistenceOne/ibc-apps/middleware/packet-forward-middleware/v7 v7.0.0-20240109170424-f4a8f29910eb h1:diFYtzQUDh2WKIy21ywl45rWidpVbd0jAKcR0ddlndw=
+github.com/persistenceOne/ibc-apps/middleware/packet-forward-middleware/v7 v7.0.0-20240109170424-f4a8f29910eb/go.mod h1:v+x4hTcShRZylXZNsK5zXFQ8QMV448rbIY4e9HDXBkY=
+github.com/persistenceOne/ibc-apps/modules/ibc-hooks/v7 v7.0.0-20240109170424-f4a8f29910eb h1:p0eVmgkvqjwWpqxn1YtKRj+tVa1+3B3JELK+riYSHQM=
+github.com/persistenceOne/ibc-apps/modules/ibc-hooks/v7 v7.0.0-20240109170424-f4a8f29910eb/go.mod h1:fbwFAk6oxuKiFvp5SLCItT34A1+F5LjGcMNOTuU8h4c=
 github.com/persistenceOne/ibc-go/v7 v7.2.0-lsm3 h1:U4NsRXpg9VHCFVyrk1JfG+sIA3frtZIWbtNmmumjta8=
 github.com/persistenceOne/ibc-go/v7 v7.2.0-lsm3/go.mod h1:PDvFOPEd8Fz25qBmhX7KXSPX4COyGnytKweRdEP1yfA=
 github.com/persistenceOne/persistence-sdk/v2 v2.1.1 h1:fo8Og2QkjsqqhH/wiEiOSB99M2Jr0kLqirU2xhJRZfQ=


### PR DESCRIPTION
## 1. Overview

https://github.com/persistenceOne/ibc-apps/releases

Includes this fix:
https://github.com/persistenceOne/ibc-apps/commit/7c8f814d3b79cd05abb437f8a4362c2763affcc0

## 2. How to test/use

e2e tests work within pfm middleware in ibc-apps
