### PR TITLE
chore: prepare v11.13.0-rc0 for testnet

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -56,13 +56,13 @@ import (
 
 	"github.com/persistenceOne/persistenceCore/v11/app/keepers"
 	"github.com/persistenceOne/persistenceCore/v11/app/upgrades"
-	v11_12_0 "github.com/persistenceOne/persistenceCore/v11/app/upgrades/v11.12.0"
+	v11_13_0_rc0 "github.com/persistenceOne/persistenceCore/v11/app/upgrades/testnet/v11.13.0-rc0"
 	"github.com/persistenceOne/persistenceCore/v11/client/docs"
 )
 
 var (
 	DefaultNodeHome string
-	Upgrades        = []upgrades.Upgrade{v11_12_0.Upgrade}
+	Upgrades        = []upgrades.Upgrade{v11_13_0_rc0.Upgrade}
 	ModuleBasics    = module.NewBasicManager(keepers.AppModuleBasics...)
 )
 

--- a/app/upgrades/testnet/v11.13.0-rc0/constants.go
+++ b/app/upgrades/testnet/v11.13.0-rc0/constants.go
@@ -1,0 +1,18 @@
+package v11_13_0_rc0
+
+import (
+	store "github.com/cosmos/cosmos-sdk/store/types"
+
+	"github.com/persistenceOne/persistenceCore/v11/app/upgrades"
+)
+
+const (
+	// UpgradeName defines the on-chain upgrade name.
+	UpgradeName = "v11.13.0-rc0"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
+}

--- a/app/upgrades/testnet/v11.13.0-rc0/upgrades.go
+++ b/app/upgrades/testnet/v11.13.0-rc0/upgrades.go
@@ -1,0 +1,15 @@
+package v11_13_0_rc0
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/persistenceOne/persistenceCore/v11/app/upgrades"
+)
+
+func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx.Logger().Info("running module migrations...")
+		return args.ModuleManager.RunMigrations(ctx, args.Configurator, vm)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/cosmos/ibc-go/v7 v7.4.0
 	github.com/gorilla/mux v1.8.1
 	github.com/persistenceOne/persistence-sdk/v2 v2.2.0
-	github.com/persistenceOne/pstake-native/v2 v2.14.0
+	github.com/persistenceOne/pstake-native/v2 v2.15.0-rc0
 	github.com/prometheus/client_golang v1.16.0
 	github.com/skip-mev/pob v1.0.5
 	github.com/spf13/cast v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/cosmos/ibc-go/v7 v7.4.0
 	github.com/gorilla/mux v1.8.1
 	github.com/persistenceOne/persistence-sdk/v2 v2.2.0
-	github.com/persistenceOne/pstake-native/v2 v2.15.0-rc0
+	github.com/persistenceOne/pstake-native/v2 v2.15.0-rc1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/skip-mev/pob v1.0.5
 	github.com/spf13/cast v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1034,8 +1034,8 @@ github.com/persistenceOne/cosmos-sdk v0.47.10-lsm-rc0 h1:lbSQZUdaaKIpoSAznVESl0v
 github.com/persistenceOne/cosmos-sdk v0.47.10-lsm-rc0/go.mod h1:Q/eHvXB0Awenk3NCh77NvjpeKGPigawFHIXlz2ayfos=
 github.com/persistenceOne/persistence-sdk/v2 v2.2.0 h1:ZsBsy/HElkwjPXoASI7CptMFY9C3C/d27G+8bxFDzQw=
 github.com/persistenceOne/persistence-sdk/v2 v2.2.0/go.mod h1:8VgozZWTPLMdlzsyiuGI0+vLo2fvGYSj/YKM9kiJwrI=
-github.com/persistenceOne/pstake-native/v2 v2.14.0 h1:3FghzZZFA1UX/UrZNiVh5kPX2CSQUxZihZ5l80VWhms=
-github.com/persistenceOne/pstake-native/v2 v2.14.0/go.mod h1:FcLbnTasZfKKKQJ6nzgzdkDqb3dUlIyraqcsj7DMTfE=
+github.com/persistenceOne/pstake-native/v2 v2.15.0-rc0 h1:7qidsxE0pCDwk2GDkeh+1zvzc7WH4Hfsp5VwQLjc25U=
+github.com/persistenceOne/pstake-native/v2 v2.15.0-rc0/go.mod h1:FcLbnTasZfKKKQJ6nzgzdkDqb3dUlIyraqcsj7DMTfE=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=

--- a/go.sum
+++ b/go.sum
@@ -1034,8 +1034,8 @@ github.com/persistenceOne/cosmos-sdk v0.47.10-lsm-rc0 h1:lbSQZUdaaKIpoSAznVESl0v
 github.com/persistenceOne/cosmos-sdk v0.47.10-lsm-rc0/go.mod h1:Q/eHvXB0Awenk3NCh77NvjpeKGPigawFHIXlz2ayfos=
 github.com/persistenceOne/persistence-sdk/v2 v2.2.0 h1:ZsBsy/HElkwjPXoASI7CptMFY9C3C/d27G+8bxFDzQw=
 github.com/persistenceOne/persistence-sdk/v2 v2.2.0/go.mod h1:8VgozZWTPLMdlzsyiuGI0+vLo2fvGYSj/YKM9kiJwrI=
-github.com/persistenceOne/pstake-native/v2 v2.15.0-rc0 h1:7qidsxE0pCDwk2GDkeh+1zvzc7WH4Hfsp5VwQLjc25U=
-github.com/persistenceOne/pstake-native/v2 v2.15.0-rc0/go.mod h1:FcLbnTasZfKKKQJ6nzgzdkDqb3dUlIyraqcsj7DMTfE=
+github.com/persistenceOne/pstake-native/v2 v2.15.0-rc1 h1:kOJ8E/N9QPFbH2JaoDrhlnwP88o9NZ7Mp44KAiBdNN8=
+github.com/persistenceOne/pstake-native/v2 v2.15.0-rc1/go.mod h1:FcLbnTasZfKKKQJ6nzgzdkDqb3dUlIyraqcsj7DMTfE=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -29,8 +29,8 @@ const (
 func TestPersistenceUpgradeBasic(t *testing.T) {
 	var (
 		chainName            = "persistence"
-		initialVersion       = "v11.11.0"
-		upgradeName          = "v11.12.0"
+		initialVersion       = "v11.12.0"
+		upgradeName          = "v11.13.0-rc0"
 		upgradeRepo          = PersistenceCoreImage.Repository
 		upgradeBranchVersion = PersistenceCoreImage.Version
 	)

--- a/interchaintest/liquidstake_stkxprt_globalcap_test.go
+++ b/interchaintest/liquidstake_stkxprt_globalcap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"cosmossdk.io/math"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -166,6 +167,7 @@ func TestLiquidStakeGlobalCapStkXPRT(t *testing.T) {
 	)
 	require.NoError(t, err, "error submitting liquidstake validators whitelist update tx")
 	require.Equal(t, uint32(0), txResp.Code, txResp.RawLog)
+	time.Sleep(6 * time.Second)
 
 	stakingParams, _, err := chainNode.ExecQuery(ctx, "staking", "params")
 	require.NoError(t, err)

--- a/interchaintest/liquidstake_stkxprt_globalcap_test.go
+++ b/interchaintest/liquidstake_stkxprt_globalcap_test.go
@@ -2,11 +2,8 @@ package interchaintest
 
 import (
 	"context"
-	"encoding/json"
-	"testing"
-	"time"
-
 	"cosmossdk.io/math"
+	"encoding/json"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -16,6 +13,7 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/testutil"
 	"github.com/stretchr/testify/require"
+	"testing"
 
 	"github.com/persistenceOne/persistenceCore/v11/interchaintest/helpers"
 )
@@ -47,9 +45,6 @@ func TestLiquidStakeGlobalCapStkXPRT(t *testing.T) {
 	}, cosmos.GenesisKV{
 		Key:   "app_state.liquidstake.params.module_paused",
 		Value: false,
-	}, cosmos.GenesisKV{
-		Key:   "app_state.epochs.epochs.0.duration",
-		Value: "5s",
 	})
 
 	ic, chain := CreateChain(t, ctx, validatorsCount, 0, overridesKV...)
@@ -167,7 +162,6 @@ func TestLiquidStakeGlobalCapStkXPRT(t *testing.T) {
 	)
 	require.NoError(t, err, "error submitting liquidstake validators whitelist update tx")
 	require.Equal(t, uint32(0), txResp.Code, txResp.RawLog)
-	time.Sleep(6 * time.Second)
 
 	stakingParams, _, err := chainNode.ExecQuery(ctx, "staking", "params")
 	require.NoError(t, err)

--- a/interchaintest/liquidstake_stkxprt_globalcap_test.go
+++ b/interchaintest/liquidstake_stkxprt_globalcap_test.go
@@ -46,6 +46,9 @@ func TestLiquidStakeGlobalCapStkXPRT(t *testing.T) {
 	}, cosmos.GenesisKV{
 		Key:   "app_state.liquidstake.params.module_paused",
 		Value: false,
+	}, cosmos.GenesisKV{
+		Key:   "app_state.epochs.epochs.0.duration",
+		Value: "5s",
 	})
 
 	ic, chain := CreateChain(t, ctx, validatorsCount, 0, overridesKV...)

--- a/interchaintest/liquidstake_stkxprt_test.go
+++ b/interchaintest/liquidstake_stkxprt_test.go
@@ -2,10 +2,8 @@ package interchaintest
 
 import (
 	"context"
-	"encoding/json"
-	"testing"
-
 	"cosmossdk.io/math"
+	"encoding/json"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -16,6 +14,8 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/testutil"
 	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
 
 	"github.com/persistenceOne/persistenceCore/v11/interchaintest/helpers"
 )
@@ -158,8 +158,8 @@ func TestLiquidStakeStkXPRT(t *testing.T) {
 	)
 	require.NoError(t, err, "error submitting liquidstake validators whitelist update tx")
 	require.Equal(t, uint32(0), txResp.Code, txResp.RawLog)
-
 	// Liquid stake XPRT from the first user (5 XPRT)
+	time.Sleep(6 * time.Second)
 
 	firstUserLiquidStakeAmount := sdk.NewInt(5_000_000)
 	firstUserLiquidStakeCoins := sdk.NewCoin(testDenom, firstUserLiquidStakeAmount)

--- a/interchaintest/liquidstake_stkxprt_test.go
+++ b/interchaintest/liquidstake_stkxprt_test.go
@@ -46,6 +46,9 @@ func TestLiquidStakeStkXPRT(t *testing.T) {
 	overridesKV = append(overridesKV, cosmos.GenesisKV{
 		Key:   "app_state.liquidstake.params.module_paused",
 		Value: false,
+	}, cosmos.GenesisKV{
+		Key:   "app_state.epochs.epochs.0.duration",
+		Value: "5s",
 	})
 
 	// important overrides: fast voting for quick proposal passing

--- a/interchaintest/liquidstake_stkxprt_test.go
+++ b/interchaintest/liquidstake_stkxprt_test.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/persistenceOne/persistenceCore/v11/interchaintest/helpers"
 	liquidstaketypes "github.com/persistenceOne/pstake-native/v2/x/liquidstake/types"
 	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
@@ -15,9 +16,6 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v7/testutil"
 	"github.com/stretchr/testify/require"
 	"testing"
-	"time"
-
-	"github.com/persistenceOne/persistenceCore/v11/interchaintest/helpers"
 )
 
 // TestLiquidStakeStkXPRT runs the flow of liquid XPRT staking using
@@ -46,9 +44,6 @@ func TestLiquidStakeStkXPRT(t *testing.T) {
 	overridesKV = append(overridesKV, cosmos.GenesisKV{
 		Key:   "app_state.liquidstake.params.module_paused",
 		Value: false,
-	}, cosmos.GenesisKV{
-		Key:   "app_state.epochs.epochs.0.duration",
-		Value: "5s",
 	})
 
 	// important overrides: fast voting for quick proposal passing
@@ -159,7 +154,6 @@ func TestLiquidStakeStkXPRT(t *testing.T) {
 	require.NoError(t, err, "error submitting liquidstake validators whitelist update tx")
 	require.Equal(t, uint32(0), txResp.Code, txResp.RawLog)
 	// Liquid stake XPRT from the first user (5 XPRT)
-	time.Sleep(6 * time.Second)
 
 	firstUserLiquidStakeAmount := sdk.NewInt(5_000_000)
 	firstUserLiquidStakeCoins := sdk.NewCoin(testDenom, firstUserLiquidStakeAmount)


### PR DESCRIPTION
## 1. Overview

Updates pstake version to v2.15.0-rc1 https://github.com/persistenceOne/pstake-native/releases/tag/v2.15.0-rc0
