### PR TITLE
chore: update v13 mainnet upgrade instructions

### DIFF
--- a/app/upgrades/v13.0.0/upgrades.go
+++ b/app/upgrades/v13.0.0/upgrades.go
@@ -2,7 +2,10 @@ package v13_0_0
 
 import (
 	"context"
+	"errors"
+
 	ibctmtypes "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint"
+	halvingtypes "github.com/persistenceOne/persistence-sdk/v4/x/halving/types"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -23,6 +26,21 @@ func CreateUpgradeHandler(args upgrades.UpgradeHandlerArgs) upgradetypes.Upgrade
 		params := args.Keepers.IBCKeeper.ClientKeeper.GetParams(sdkCtx)
 		params.AllowedClients = []string{ibctmtypes.ModuleName}
 		args.Keepers.IBCKeeper.ClientKeeper.SetParams(sdkCtx, params)
+
+		sdkCtx.Logger().Info("setting halving params")
+		halvingParamSubspace, ok := args.Keepers.ParamsKeeper.GetSubspace(halvingtypes.DefaultParamspace)
+		if !ok {
+			return vm, errors.New("halving param subspace not found")
+		}
+		var halvingBlockHeight uint64
+		halvingParamSubspace.Get(sdkCtx, halvingtypes.KeyBlockHeight, &halvingBlockHeight)
+
+		halvingParams := halvingtypes.Params{BlockHeight: halvingBlockHeight}
+		err = args.Keepers.HalvingKeeper.SetParams(sdkCtx, halvingParams)
+		if err != nil {
+			return vm, err
+		}
+
 		return vm, nil
 	}
 }


### PR DESCRIPTION
udpate halving params on mainnet upgrade instrucitons